### PR TITLE
Add webdav

### DIFF
--- a/mailu/helm-lint-values.yaml
+++ b/mailu/helm-lint-values.yaml
@@ -64,7 +64,6 @@ roundcube:
   image:
     tag: master
 
-
 webdav:
   logLevel: WARNING
   image:

--- a/mailu/templates/webdav-ingress.yaml
+++ b/mailu/templates/webdav-ingress.yaml
@@ -1,0 +1,34 @@
+{{- $fullname := (include "mailu.fullname" .) }}
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/auth-url: http://{{ $fullname }}-admin.{{ .Release.Namespace }}.svc.cluster.local/internal/auth/basic
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/webdav/(.*) /$1 break;
+      auth_request_set $user $upstream_http_x_user;
+      proxy_set_header X-Remote-User $user;
+      proxy_set_header X-Script-Name /webdav;
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  labels:
+    app: {{ $fullname }}
+    component: webdav
+  name: mailu-webdav-ingress
+spec:
+{{- range .Values.hostnames }}
+  rules:
+  - host: "{{ . }}"
+    http:
+      paths:
+      - path: "/webdav"
+        backend:
+          serviceName: {{ $fullname }}-webdav
+          servicePort: 5232
+{{- end }}
+  tls:
+  - secretName: {{ $fullname }}-certificates
+    hosts:
+{{- range .Values.hostnames }}
+    - "{{ . }}"
+{{- end }}

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -1,0 +1,63 @@
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/webdav.yaml
+
+{{ if .Capabilities.APIVersions.Has "apps/v1/Deployment" }}
+apiVersion: apps/v1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end }}
+kind: Deployment
+metadata:
+  name: {{ include "mailu.fullname" . }}-webdav
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "mailu.fullname" . }}
+      component: webdav
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ include "mailu.fullname" . }}
+        component: webdav
+    spec:
+      containers:
+      - name: webdav
+        image: {{ .Values.webdav.image.repository }}:{{ default .Values.mailuVersion .Values.webdav.image.tag }}
+        imagePullPolicy: Always
+        volumeMounts:
+          - mountPath: /data
+            name: data
+            subPath: dav
+        ports:
+          - containerPort: 5232
+        {{- with .Values.webdav.resources }}
+        resources:
+        {{- .|toYaml|nindent 10}}
+        {{- end }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "mailu.claimName" . }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mailu.fullname" . }}-webdav
+  labels:
+    app: {{ include "mailu.fullname" . }}
+    component: webdav
+spec:
+  selector:
+    app: {{ include "mailu.fullname" . }}
+    component: webdav
+  ports:
+  - name: http-ui
+    port: 5232
+    protocol: TCP

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -174,9 +174,16 @@ roundcube:
 webdav:
   # logLevel: WARNING
   image:
-    repository: mailu/clamav
+    repository: mailu/radicale
     # tag defaults to mailuVersion
     # tag: master
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
 
 mysql:
   image:


### PR DESCRIPTION
Hi !

I add webdav support with the mailu/radicale docker image. In order to do this, I add two new files:

- webdav-ingress.yaml 
- webdav.yaml 

**webdav-ingress** add an ingress with a basic authentication against "internal/auth/basic" of the admin service.

Let me know if I did something wrond and if I need to modify something.