### PR TITLE
Fix external database not being used

### DIFF
--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -89,10 +89,11 @@ spec:
           - name: DB_NAME
             value: {{ required "database.mysql.database" .Values.database.mysql.database }}
           - name: DB_HOST
-            {{- if .Values.database.host }}
-            value: {{ .Values.database.host }}
-            {{- end }}
+            {{- if .Values.database.mysql.host }}
+            value: {{ .Values.database.mysql.host }}
+            {{- else }}
             value: {{ include "mailu.fullname" . }}-mysql
+            {{- end }}
           {{- else }}
           value: {{ required "database.type must be one of sqlite/mysql" .None }}
           {{- end }}


### PR DESCRIPTION
The current admin.yaml references .Values.database.host while the path should be .Values.database.mysql.host
Additionally, I wrapped the include "mailu.fullname" usage in an else-branch