### PR TITLE
Add RELAYHOST support

### DIFF
--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -63,14 +63,14 @@ spec:
             value: {{ include "mailu.fullname" . }}-admin
           - name: FRONT_ADDRESS
             value: {{ include "mailu.fullname" . }}-front
-          {{ if hasKey .Values.external_relay "relayhost" }}
+          {{ if hasKey .Values.external_relay "host" }}
           - name: RELAYHOST
-            value: "{{ .Values.external_relay.relayhost }}"
-          {{ if hasKey .Values.external_relay "relayuser" }}
+            value: "{{ .Values.external_relay.host }}"
+          {{ if hasKey .Values.external_relay "username" }}
           - name: RELAYUSER
-            value: "{{ .Values.external_relay.relayuser }}"
+            value: "{{ .Values.external_relay.username }}"
           - name: RELAYPASSWORD
-            value: "{{ .Values.external_relay.relaypassword }}"
+            value: "{{ .Values.external_relay.password }}"
           {{- end}}
           {{- end}}
         ports:

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -63,6 +63,16 @@ spec:
             value: {{ include "mailu.fullname" . }}-admin
           - name: FRONT_ADDRESS
             value: {{ include "mailu.fullname" . }}-front
+          {{ if hasKey .Values.external_relay "relayhost" }}
+          - name: RELAYHOST
+            value: "{{ .Values.external_relay.relayhost }}"
+          {{ if hasKey .Values.external_relay "relayuser" }}
+          - name: RELAYUSER
+            value: "{{ .Values.external_relay.relayuser }}"
+          - name: RELAYPASSWORD
+            value: "{{ .Values.external_relay.relaypassword }}"
+          {{- end}}
+          {{- end}}
         ports:
           - name: smtp
             containerPort: 25

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -69,6 +69,11 @@ database:
     # roundcubeUser: roundcube
     # roundcubePassword: chang3m3!
 
+external_relay: {}
+#    relayhost: "[domain.tld]:port"
+#    relayuser: username
+#    relaypassword: SECRET
+
 persistence:
   size: 100Gi
   accessMode: ReadWriteOnce

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -70,9 +70,9 @@ database:
     # roundcubePassword: chang3m3!
 
 external_relay: {}
-#    relayhost: "[domain.tld]:port"
-#    relayuser: username
-#    relaypassword: SECRET
+#    host: "[domain.tld]:port"
+#    username: username
+#    password: SECRET
 
 persistence:
   size: 100Gi
@@ -117,7 +117,7 @@ front:
     # tag defaults to mailuVersion
     # tag: master
   resources:
-    requests: 
+    requests:
       memory: 100Mi
       cpu: 100m
     limits:


### PR DESCRIPTION
Hi,
Mailu supports setting a RELAYHOST along with login credentials via the environment variables.
This patch/PR adds that basic usage to the Helm-chart