### PR TITLE
Add ability to run TLS webmail without external NGINX.

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -39,6 +39,8 @@
 | `persistence.existingClaim`       | existing PVC                         | not set                                   |
 | `persistence.claimNameOverride`   | override the generated claim name    | not set                                   |
 | `webdav.enabled`                  | enable webdav server                 | `false`                                   |
+| `ingress.externalIngress`         | Use externally provided nginx        | `true`                                    |
+| `ingress.tlsFlavor`               | [Choose from these](https://mailu.io/1.7/compose/setup.html#tls-certificates)  | `cert`                                   |
 
 ### Example values.yaml to get started
 
@@ -76,3 +78,13 @@ If neither `persistence.hostPath` nor `persistence.existingClaim` is set, a new 
 can be overridden with `persistence.claimNameOverride`.
 
 The `persistence.storageClass` is not set by default. It can be set to `-` to have an empty storageClassName or to anything else to use this name.
+
+## Ingress
+
+The default ingress is handled externally. In some situations, this is problematic, such as when webmail should be accessible
+ on the same address as the exposed ports. Kubernetes services cannot provide such capabilities without vendor-specific annotations.
+ 
+By setting `ingress.externalIngress` to false, the internal NGINX instance provided by `front` will configure TLS according to
+ `ingress.tlsFlavor` and redirect `http` scheme connections to `https`. 
+ 
+ CAUTION: This configuration exposes `/admin` to all clients with access to the web UI.

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -20,6 +20,7 @@
 | `mailuVersion`                    | Version/tag of mailu images          | `master`                                  |
 | `logLevel`                        | Level of logging                     | `WARNING`                                 |
 | `nameOverride`                    | Override the resource name prefix    | `mailu`                                   |
+| `clusterDomain`                   | Change the cluster DNS root          | `cluster.local`                           |
 | `fullnameOverride`                | Override the full resource names     | `mailu-{release-name}` (or `mailu` if release-name is `mailu`) |
 | `hostnames`                       | List of hostnames to generate certificates and ingresses for | not set           |
 | `domain`                          | Mail domain name, see https://github.com/Mailu/Mailu/blob/master/docs/faq.rst#what-is-the-difference-between-domain-and-hostnames | not set |

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -1,5 +1,6 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/front.yaml
 
+{{- $clusterDomain := default "cluster.local" .Values.clusterDomain}}
 {{ if .Capabilities.APIVersions.Has "apps/v1/DaemonSet" }}
 apiVersion: apps/v1
 {{ else }}
@@ -39,19 +40,19 @@ spec:
           - name: LOG_LEVEL
             value: {{ default .Values.logLevel .Values.front.logLevel }}
           - name: KUBERNETES_INGRESS
-            value: "true"
+            value: "{{ .Values.ingress.externalIngress }}"
           - name: TLS_FLAVOR
-            value: cert
+            value: {{ default "cert" .Values.ingress.tlsFlavor }}
           - name: HOSTNAMES
             value: "{{ join "," .Values.hostnames }}"
           - name: ADMIN_ADDRESS
-            value: {{ include "mailu.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local
+            value: {{ include "mailu.fullname" . }}-admin.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
           - name: ANTISPAM_WEBUI_ADDRESS
-            value: {{ include "mailu.fullname" . }}-rspamd.{{ .Release.Namespace }}.svc.cluster.local:11334
+            value: {{ include "mailu.fullname" . }}-rspamd.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:11334
           - name: WEBMAIL
             value: roundcube
           - name: WEBMAIL_ADDRESS
-            value: {{ include "mailu.fullname" . }}-roundcube.{{ .Release.Namespace }}.svc.cluster.local
+            value: {{ include "mailu.fullname" . }}-roundcube.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
           - name: MESSAGE_SIZE_LIMIT
             value: "{{ mul .Values.mail.messageSizeLimitInMegabytes (mul 1024 1024) }}"
           - name: WEB_WEBMAIL
@@ -68,7 +69,7 @@ spec:
           - name: WEBDAV
             value: radicale
           - name: WEBDAV_ADDRESS
-            value: {{ include "mailu.fullname" . }}-webdav.{{ .Release.Namespace }}.svc.cluster.local:5232
+            value: {{ include "mailu.fullname" . }}-webdav.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:5232
           {{- end }}
         ports:
           - name: pop3
@@ -189,3 +190,8 @@ spec:
   - name: http
     port: 80
     protocol: TCP
+{{ if not .Values.ingress.externalIngress }}
+  - name: http
+    port: 443
+    protocol: TCP
+{{end}}

--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -1,8 +1,8 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin-ingress.yaml
 
 {{- $fullname := (include "mailu.fullname" .) }}
-
-apiVersion: extensions/v1beta1
+{{ if .Values.ingress.externalIngress }}
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullname }}-ingress
@@ -28,3 +28,4 @@ spec:
           serviceName: {{ $fullname }}-front
           servicePort: 80
 {{- end }}
+{{ end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -20,6 +20,7 @@
 
 nameOverride: ""
 fullnameOverride: ""
+clusterDomain: cluster.local
 
 nodeSelector: {}
 
@@ -63,6 +64,11 @@ mail:
 certmanager:
   issuerType: ClusterIssuer
   issuerName: letsencrypt
+
+# Set ingress and loadbalancer config
+ingress:
+  externalIngress: true
+  tlsFlavor: cert
 
 # Frontend load balancer for non-HTTP(s) services
 front:


### PR DESCRIPTION
PR provides ability for web endpoints to be TLS protected via nginx instance provided in `front` container. Also add ability to change DNS root domain for an installation from `cluster.local`.