### PR TITLE
add ability specifying annotations for the PVC

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -37,6 +37,7 @@
 | `persistence.size`                | requested PVC size                   | `100Gi`                                   |
 | `persistence.storageClass`        | storageClass to use for persistence  | not set                                   |
 | `persistence.accessMode`          | accessMode to use for persistence    | `ReadWriteOnce`                           |
+| `persistence.annotations`          | Annotations to use in the PVC.    | `{}`                           |
 | `persistence.hostPath`            | path of the hostPath persistence     | not set                                   |
 | `persistence.existingClaim`       | existing PVC                         | not set                                   |
 | `persistence.claimNameOverride`   | override the generated claim name    | not set                                   |

--- a/mailu/helm-lint-values.yaml
+++ b/mailu/helm-lint-values.yaml
@@ -22,6 +22,7 @@ persistence:
   claimNameOverride: false
   existingClaim: false
   hostPath: false
+  annotations: {}
 
 database:
   mysql:

--- a/mailu/templates/pvc.yaml
+++ b/mailu/templates/pvc.yaml
@@ -9,6 +9,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "mailu.fullname" . }}-storage
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - ReadWriteMany
@@ -54,6 +58,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "mailu.claimName" . }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -42,6 +42,8 @@ database:
 persistence:
   size: 100Gi
   accessMode: ReadWriteOnce
+  #annotations:
+  #  "helm.sh/resource-policy": keep
   #hostPath: /path/on/the/host
   #existingClaim: name-of-existing.claim
   #storageClass: "-"


### PR DESCRIPTION
This commit allows specifying annotations for the PVC.
This is useful for example to add the annotation for helm to keep the PVC when deleting the chart in order to avoid accidentally losing the data.