### PR TITLE
add ability specifying annotations for the ingress

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -43,6 +43,7 @@
 | `webdav.enabled`                  | enable webdav server                 | `false`                                   |
 | `ingress.externalIngress`         | Use externally provided nginx        | `true`                                    |
 | `ingress.tlsFlavor`               | [Choose from these](https://mailu.io/1.7/compose/setup.html#tls-certificates)  | `cert`                                   |
+| `ingress.annotations`               | Annotations for the ingress resource, if enabled. Useful e.g. for configuring the NGINX controller configuration.  | `nginx.ingress.kubernetes.io/proxy-body-size: "0"`                                   |
 | `roundcube.enabled`               | enable roundcube webmail             | `true`                                    |
 | `clamav.enabled`                  | enable clamav antivirus              | `true`                                    |
 

--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -6,8 +6,10 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullname }}-ingress
+{{- if .Values.ingress.annotations }}
   annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ $fullname }}
     component: admin

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -69,6 +69,8 @@ certmanager:
 ingress:
   externalIngress: true
   tlsFlavor: cert
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
 # Frontend load balancer for non-HTTP(s) services
 front:


### PR DESCRIPTION
This commit allows specifying annotations for the ingress.
This is useful for example to customize the NGINX controller configuration.

Also this feature was asked here: https://github.com/Mailu/helm-charts/pull/26#discussion_r397964807