### PR TITLE
Add ability to set nameservers for rspamd

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -47,6 +47,7 @@
 | `ingress.annotations`               | Annotations for the ingress resource, if enabled. Useful e.g. for configuring the NGINX controller configuration.  | `nginx.ingress.kubernetes.io/proxy-body-size: "0"`                                   |
 | `roundcube.enabled`               | enable roundcube webmail             | `true`                                    |
 | `clamav.enabled`                  | enable clamav antivirus              | `true`                                    |
+| `rspamd.nameservers`                  | Custom nameservers for rspamd              | `{}`                                    |
 
 ### Example values.yaml to get started
 

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -25,6 +25,14 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.rspamd.nameservers }}
+      {{- with .Values.rspamd.nameservers }}
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- end }}
       containers:
       - name: rspamd
         image: {{ .Values.rspamd.image.repository }}:{{ default .Values.mailuVersion .Values.rspamd.image.tag }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -149,6 +149,9 @@ rspamd:
     repository: mailu/rspamd
     # tag defaults to mailuVersion
     # tag: master
+  nameservers: {}
+  #  - 8.8.8.8
+  #  - 8.8.4.4
   resources:
     requests:
       memory: 100Mi


### PR DESCRIPTION
When deploying mailu on a cloud provider, the nameservers of the node are often blocked by DNSWL.
This PR adds the ability to set a different nameserver and thus avoid being blocked by DNSWL.

Ideally it would be better to have Unbound into the chart but I don't know how to pull that off.