### PR TITLE
Add mysql support for roundcube

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.0.6
+version: 0.0.7
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -29,8 +29,8 @@
 | `subnet`                          | Subnet of PODs, used to configure from which IPs internal requests are allowed | `10.42.0.0/16` |
 | `mail.messageSizeLimitInMegabytes`| Message size limit in Megabytes      | `50`                                      |
 | `mail.authRatelimit`              | Rate limit for authentication requests | `10/minute;1000/hour`                   |
-| `initialAccount.username`         | Local part (part before @) for initial admin account | not set                    |
-| `initialAccount.domain`           | Domain part (part after @) for initial admin account | not set                  |
+| `initialAccount.username`         | Local part (part before @) for initial admin account | not set                   |
+| `initialAccount.domain`           | Domain part (part after @) for initial admin account | not set                   |
 | `initialAccount.password`         | Password for initial admin account   | not set                                   |
 | `certmanager.issuerType`          | Issuer type for cert manager         | `ClusterIssuer`                           |
 | `certmanager.issuerName`          | Name of a preconfigured cert issuer  | `letsencrypt`                             |
@@ -47,6 +47,9 @@
 | `ingress.annotations`               | Annotations for the ingress resource, if enabled. Useful e.g. for configuring the NGINX controller configuration.  | `nginx.ingress.kubernetes.io/proxy-body-size: "0"`                                   |
 | `roundcube.enabled`               | enable roundcube webmail             | `true`                                    |
 | `clamav.enabled`                  | enable clamav antivirus              | `true`                                    |
+| `database.type`                   | type of database used for mailu      | `sqlite`                                  |
+| `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
+| `database.mysql.*`                | mysql specific settings, see below   | not set                                   |
 
 ### Example values.yaml to get started
 
@@ -103,3 +106,23 @@ By setting `ingress.externalIngress` to false, the internal NGINX instance provi
  `ingress.tlsFlavor` and redirect `http` scheme connections to `https`. 
  
  CAUTION: This configuration exposes `/admin` to all clients with access to the web UI.
+
+## Database
+
+By default both, mailu and dovecot uses an embedded sqlite database. The chart allows to use an embedded or external mysql database instead. It can be controlled by the following values:
+
+### Using mysql for mailu
+
+Set ``database.type`` to ``mysql``. ``database.mysql.database``, ``database.mysql.user``, and ``database.mysql.password`` must also be set.
+
+### Using mysql for roundcube
+
+Set ``database.roundcubeType`` to ``mysql``. ``database.mysql.roundcubeDatabase``, ``database.mysql.roundcubeUser``, and ``database.mysql.roundcubePassword`` must also be set.
+
+### Using the internal mysql database
+
+The chart deploys an instance of mariadb if either ``database.type`` or ``database.roundcubeType`` is set to ``mysql``. If both are set, they use the same mariadb instance. A database root password can be set with ``database.mysql.rootPassword``. If not set, a random root password will be used.
+
+### Using an external mysql database
+
+An external mysql database can be used by setting ``database.mysql.host``. The chart does not support different mysql hosts for mailu and dovecot. Using other mysql ports than the default 3306 port is also nur supported by the chart.

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -82,6 +82,8 @@ spec:
           - name: WEBDAV_ADDRESS
             value: {{ include "mailu.fullname" . }}-webdav.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:5232
           {{- end }}
+          - name: SUBNET
+            value: {{ .Values.subnet }}
         ports:
           - name: pop3
             containerPort: 110

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -61,7 +61,7 @@ spec:
 {{- if (eq .Values.database.type "roundcubeType") }}
           - name: initscripts
             mountPath: /docker-entrypoint-initdb.d/
-{{- end }
+{{- end }}
         env:
           {{ if .Values.database.mysql.rootPassword }}
           - name: MYSQL_ROOT_PASSWORD

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -1,6 +1,6 @@
-{{ if and (or (eq .Values.database.type "mysql") (eq .Values.database.type "roundcubeType")) (not .Values.database.mysql.host) }}
+{{ if and (or (eq .Values.database.type "mysql") (eq .Values.database.roundcubeType "mysql")) (not .Values.database.mysql.host) }}
 
-{{ if (eq .Values.database.type "roundcubeType") }}
+{{ if (eq .Values.database.roundcubeType "mysql") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -58,7 +58,7 @@ spec:
           - name: data
             subPath: mysql
             mountPath: /var/lib/mysql
-{{- if (eq .Values.database.type "roundcubeType") }}
+{{- if (eq .Values.database.roundcubeType "mysql") }}
           - name: initscripts
             mountPath: /docker-entrypoint-initdb.d/
 {{- end }}

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -1,4 +1,18 @@
-{{ if and (eq .Values.database.type "mysql") (not .Values.database.mysql.host) }}
+{{ if and (or (eq .Values.database.type "mysql") (eq .Values.database.type "roundcubeType")) (not .Values.database.mysql.host) }}
+
+{{ if (eq .Values.database.type "roundcubeType") }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mailu.fullname" . }}-mysql-init
+data:
+  extra.sql: >
+    CREATE DATABASE IF NOT EXISTS {{ required "database.mysql.roundcubeDatabase" .Values.database.mysql.roundcubeDatabase }};
+    GRANT ALL ON {{ required "database.mysql.roundcubeDatabase" .Values.database.mysql.roundcubeDatabase }}.* TO
+      '{{ required "database.mysql.roundcubeUser" .Values.database.mysql.roundcubeUser }}'@'%'
+      IDENTIFIED BY '{{ required "database.mysql.roundcubePassword" .Values.database.mysql.roundcubePassword }}';
+{{ end }}
+---
 
 {{ if .Capabilities.APIVersions.Has "apps/v1/Deployment" }}
 apiVersion: apps/v1
@@ -33,13 +47,21 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: admin
+      - name: mysql
         image: {{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}
         imagePullPolicy: Always
+        args:
+          - --character-set-server=utf8
+          - --skip-character-set-client-handshake
+          - --collation-server=utf8_unicode_ci
         volumeMounts:
           - name: data
             subPath: mysql
             mountPath: /var/lib/mysql
+{{- if (eq .Values.database.type "roundcubeType") }}
+          - name: initscripts
+            mountPath: /docker-entrypoint-initdb.d/
+{{- end }
         env:
           {{ if .Values.database.mysql.rootPassword }}
           - name: MYSQL_ROOT_PASSWORD
@@ -48,17 +70,19 @@ spec:
           - name: MYSQL_RANDOM_ROOT_PASSWORD
             value: "yes"
           {{ end }}
+{{- if (eq .Values.database.type "type") }}
           - name: MYSQL_DATABASE
             value: {{ required "database.mysql.database" .Values.database.mysql.database }}
           - name: MYSQL_USER
             value: {{ required "database.mysql.user" .Values.database.mysql.user }}
           - name: MYSQL_PASSWORD
             value: {{ required "database.mysql.password" .Values.database.mysql.password }}
+{{- end }}
         ports:
           - name: mysql
             containerPort: 3306
             protocol: TCP
-        {{- with .Values.front.resources }}
+        {{- with .Values.mysql.resources }}
         resources:
         {{- .|toYaml|nindent 10}}
         {{- end }}
@@ -84,6 +108,9 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.claimName" . }}
+        - name: initscripts
+          configMap:
+            name: {{ include "mailu.fullname" . }}-mysql-init
   strategy:
     # This is a single-node mysql instance, so we need to shut down the old instance before starting a new
     type: RollingUpdate

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -51,6 +51,28 @@ spec:
             value: {{ include "mailu.fullname" . }}-front
           - name: SECRET_KEY
             value: "{{ required "secretKey" .Values.secretKey }}"
+          - name: SUBNET
+            value: {{ .Values.subnet }}
+          {{- if eq .Values.database.roundcubeType "sqlite" }}
+          - name: ROUNDCUBE_DB_FLAVOR
+            value: sqlite
+          {{- else if eq .Values.database.roundcubeType "mysql" }}
+          - name: ROUNDCUBE_DB_FLAVOR
+            value: mysql
+          - name: ROUNDCUBE_DB_USER
+            value: {{ required "database.mysql.roundcubeUser" .Values.database.mysql.roundcubeUser }}
+          - name: ROUNDCUBE_DB_PW
+            value: {{ required "database.mysql.roundcubePassword" .Values.database.mysql.roundcubePassword }}
+          - name: ROUNDCUBE_DB_NAME
+            value: {{ required "database.mysql.roundcubeDatabase" .Values.database.mysql.roundcubeDatabase }}
+          - name: ROUNDCUBE_DB_HOST
+            {{- if .Values.database.mysql.host }}
+            value: {{ .Values.database.mysql.host }}
+            {{- end }}
+            value: {{ include "mailu.fullname" . }}-mysql
+          {{- else }}
+          value: {{ required "database.type must be one of sqlite/mysql" .None }}
+          {{- end }}
         ports:
           - name: http
             containerPort: 80

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -33,19 +33,34 @@ tolerations: {}
 affinity: {}
 
 database:
-# default database is an embedded sqlite
+  # type of the database for mailu (sqlite or mysql)
+  # default database is an embedded sqlite
+  # for mysql, see settings below
   type: sqlite
+
+  # type of the database for roundcube (sqlite or mysql)
+  # default database is an embedded sqlite
+  # for mysql, see settings below
+  roundcubeType: sqlite
 
 # For mysql/mariadb use the following config:
 # Set the host to use an external database.
 # If not host is set, a database instance is created by this chart.
 #   type: mysql
   mysql: {}
+#    host: external-db-hostname
+    # root password for mysql database
+#    rootPassword: chang3m3! # can only be set for embedded mysql
+
+    # settings for mailu (required if mailu database type is "mysql")
 #    database: mailu
 #    user: mailu
 #    password: chang3m3!
-#    host: external-db-hostname
-#    rootPassword: chang3m3! # can only be set for embedded mysql
+
+    # settings for roundcube (required if roundcube database type is "mysql")
+#    roundcubeDatabase: roundcube
+#    roundcubeUser: roundcube
+#    roundcubePassword: chang3m3!
 
 persistence:
   size: 100Gi


### PR DESCRIPTION
This PR adds support for selectable database type for roundcube. It defaults to sqlite (indepenent of which database type mailu uses) for backward compatibility.