### PR TITLE
Fix Multi Host Bug

### DIFF
--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -20,8 +20,8 @@ spec:
 {{- range .Values.hostnames }}
     - "{{ . }}"
 {{- end }}
-{{- range .Values.hostnames }}
   rules:
+{{- range .Values.hostnames }}
   - host: "{{ . }}"
     http:
       paths:


### PR DESCRIPTION
If you specify multiple Hosts the Templates renders multiple "rules"-Section. But there should only be one rules-Option and then multiple Host-Sections:
See Kube-Docs: https://kubernetes.io/docs/concepts/services-networking/ingress/#name-based-virtual-hosting
```yaml
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: name-virtual-host-ingress
spec:
  rules:
  - host: foo.bar.com
    http:
      paths:
      - backend:
          serviceName: service1
          servicePort: 80
  - host: bar.foo.com
    http:
      paths:
      - backend:
          serviceName: service2
          servicePort: 80
```

Becaus of this Issue only the last specified Host is reachable from the outside.