### PR TITLE
Pod Annotation.

### DIFF
--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.admin.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: admin

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -19,6 +19,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.clamav.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: clamav

--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.dovecot.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: dovecot

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -17,6 +17,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.front.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: front

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -30,6 +30,10 @@ spec:
       component: mysql
   template:
     metadata:
+      {{- with .Values.mysql.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: mysql

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.postfix.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: postfix

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -16,6 +16,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.redis.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: redis

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -18,6 +18,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.roundcube.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: roundcube

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -17,6 +17,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.rspamd.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: rspamd

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -18,6 +18,10 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- with .Values.webdav.annotations }}
+      annotations:
+      {{- .|toYaml|nindent 8}}
+      {{- end }}
       labels:
         app: {{ include "mailu.fullname" . }}
         component: webdav

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -31,6 +31,15 @@ tolerations: {}
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+#  podAffinity:
+#    requiredDuringSchedulingIgnoredDuringExecution:
+#    - labelSelector:
+#        matchExpressions:
+#        - key: app
+#          operator: In
+#          values:
+#          - release-name
+#      topologyKey: kubernetes.io/hostname
 
 database:
   # type of the database for mailu (sqlite or mysql)
@@ -154,6 +163,8 @@ postfix:
 
 dovecot:
   # logLevel: WARNING
+  # annotations:
+    # config.linkerd.io/disable-tap: "true"
   image:
     repository: mailu/dovecot
     # tag defaults to mailuVersion


### PR DESCRIPTION
While using linkerd:
linkerd's tap service listens on 4190
```
time="2020-07-21T19:57:29Z" level=info msg="running version stable-2.8.1"
[     0.10753299s]  INFO linkerd2_proxy: Admin interface on 0.0.0.0:4191
[     0.10769128s]  INFO linkerd2_proxy: Inbound interface on 0.0.0.0:4143
[     0.10771513s]  INFO linkerd2_proxy: Outbound interface on 127.0.0.1:4140
[     0.10773837s]  INFO linkerd2_proxy: Tap interface on 0.0.0.0:4190
```
This conflicts with dovecot, preventing the pod from starting.
```
kubectl logs -f -n mail mail-mailu-dovecot-5dfb597c97-7gtsh -c admin
Error: service(managesieve-login): listen(*, 4190) failed: Address in use
Jul 21 19:57:49 master: Error: service(managesieve-login): listen(*, 4190) failed: Address in use
Fatal: Failed to start listeners
Jul 21 19:57:49 master: Fatal: Failed to start listeners
```
The solution would be to add an annotation to the deployment's pod.
https://linkerd.io/2/reference/proxy-configuration/
However, there was no ability to do so with the current chart's configuration.

PR Allows for adding annotations to all deployment pods. 

Also added an example podAffinity value as a storage class of RWO will need this to not have pods that share the same PVC stuck in pending. 