### PR TITLE
expose imaps on port 993

### DIFF
--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -79,6 +79,9 @@ spec:
           - name: imap
             containerPort: 143
             protocol: TCP
+          - name: imaps
+            containerPort: 993
+            protocol: TCP
           - name: pop3
             containerPort: 110
             protocol: TCP
@@ -139,6 +142,9 @@ spec:
     protocol: TCP
   - name: imap-default
     port: 143
+    protocol: TCP
+  - name: imap-ssl
+    port: 993
     protocol: TCP
   - name: pop3
     port: 110


### PR DESCRIPTION
For some reason, the **imaps** port (993) is not exposed. The **front** template has it already but it is missing in the **dovecot** template. This PR adds the port to the dovecot template.