### PR TITLE
add fetchmail deployment

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -60,6 +60,8 @@
 | `ingress.annotations`               | Annotations for the ingress resource, if enabled. Useful e.g. for configuring the NGINX controller configuration.  | `nginx.ingress.kubernetes.io/proxy-body-size: "0"`                                   |
 | `roundcube.enabled`               | enable roundcube webmail             | `true`                                    |
 | `clamav.enabled`                  | enable clamav antivirus              | `true`                                    |
+| `fetchmail.enabled`               | enable fetchmail                     | `false`                                   |
+| `fetchmail.delay`                 | delay between fetch attempts         | `600`                                     |
 | `database.type`                   | type of database used for mailu      | `sqlite`                                  |
 | `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
 | `database.mysql.*`                | mysql specific settings, see below   | not set                                   |

--- a/mailu/helm-lint-values.yaml
+++ b/mailu/helm-lint-values.yaml
@@ -67,8 +67,12 @@ roundcube:
   image:
     tag: master
 
-
 webdav:
+  logLevel: WARNING
+  image:
+    tag: master
+
+fetchmail:
   logLevel: WARNING
   image:
     tag: master

--- a/mailu/templates/fetchmail.yaml
+++ b/mailu/templates/fetchmail.yaml
@@ -43,14 +43,18 @@ spec:
             subPath: dovecotdata
             mountPath: /data
         env:
-          - name: LOG_LEVEL
-            value: {{ default .Values.logLevel .Values.fetchmail.logLevel }}
+          # LOG_LEVEL is called DEBUG in https://github.com/Mailu/Mailu/blob/master/optional/fetchmail/fetchmail.py#L98
+          # and will only give debug output if value is True
+          - name: DEBUG
+          {{- if (eq .Values.logLevel "DEBUG") or (eq .Values.fetchmail.logLevel "DEBUG") }}
+            value: "True"
+          {{- else }}
+            value: "False"
+          {{- end }}
           - name: HOST_SMTP
             value: {{ include "mailu.fullname" . }}-front
           - name: HOST_ADMIN
             value: {{ include "mailu.fullname" . }}-admin
-          - name: DEBUG
-            value: "False"
           - name: FETCHMAIL_DELAY
             value: "{{ .Values.fetchmail.delay }}"
         ports:

--- a/mailu/templates/fetchmail.yaml
+++ b/mailu/templates/fetchmail.yaml
@@ -1,0 +1,73 @@
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/fetchmail.yaml
+
+{{- if .Values.fetchmail.enabled }}
+
+{{ if .Capabilities.APIVersions.Has "apps/v1/Deployment" }}
+apiVersion: apps/v1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end }}
+kind: Deployment
+metadata:
+  name: {{ include "mailu.fullname" . }}-fetchmail
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "mailu.fullname" . }}
+      component: fetchmail
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ include "mailu.fullname" . }}
+        component: fetchmail
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: admin
+        image: {{ .Values.fetchmail.image.repository }}:{{ default .Values.mailuVersion .Values.fetchmail.image.tag }}
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: dovecotdata
+            mountPath: /data
+        env:
+          - name: LOG_LEVEL
+            value: {{ default .Values.logLevel .Values.fetchmail.logLevel }}
+          - name: HOST_SMTP
+            value: {{ include "mailu.fullname" . }}-front
+          - name: HOST_ADMIN
+            value: {{ include "mailu.fullname" . }}-admin
+          - name: DEBUG
+            value: "False"
+          - name: FETCHMAIL_DELAY
+            value: "{{ .Values.fetchmail.delay }}"
+        ports:
+          - containerPort: 5232
+          - containerPort: 80
+        {{- with .Values.fetchmail.resources }}
+        resources:
+        {{- .|toYaml|nindent 10}}
+        {{- end }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "mailu.claimName" . }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
+{{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -230,3 +230,19 @@ mysql:
     limits:
       memory: 512Mi
       cpu: 200m
+
+fetchmail:
+  enabled: false
+  # logLevel: WARNING
+  image:
+    repository: mailu/fetchmail
+    # tag defaults to mailuVersion
+    # tag: master
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
+  delay: 600


### PR DESCRIPTION
This adds fetchmail support to the chart.
It is disabled by default-
Included are also parameters to tune the `FETCHMAIL_DELAY`.