### PR TITLE
add config option to use Deployment/DaemonSet for front pod(s)

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -45,6 +45,7 @@
 | `initialAccount.username`         | Local part (part before @) for initial admin account | not set                   |
 | `initialAccount.domain`           | Domain part (part after @) for initial admin account | not set                   |
 | `initialAccount.password`         | Password for initial admin account   | not set                                   |
+| `front.controller.kind`           | Use Deployment or DaemonSet for `front` pod(s) | `Deployment`                    |
 | `certmanager.issuerType`          | Issuer type for cert manager         | `ClusterIssuer`                           |
 | `certmanager.issuerName`          | Name of a preconfigured cert issuer  | `letsencrypt`                             |
 | `persistence.size`                | requested PVC size                   | `100Gi`                                   |
@@ -109,6 +110,12 @@ deploy to multiple nodes, ensure that you set `persistence.accessMode` to `ReadW
 ### All services are running but authentication fails for webmail and imap
 
 It's very likely that your PODs run on a different subnet than the default `10.42.0.0/16`. Set the `subnet` value to the correct subnet and try again.
+
+## Deployment of DaemonSet for front nginx pod(s)
+
+Depending on your environment you might want to shedule "only one pod" (`Deployment`) or "one pod per node" (`DaemonSet`) for the `front` nginx pod(s).
+
+A `DaemonSet` can e.g. be usefull if you have multiple DNS entries / IPs in your MX record and want `front` to be reachable on every IP.
 
 ## Ingress
 

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -6,7 +6,11 @@ apiVersion: apps/v1
 {{ else }}
 apiVersion: extensions/v1beta1
 {{ end }}
+{{- if eq .Values.front.controller.kind "Deployment" }}
 kind: Deployment
+{{- else if eq .Values.front.controller.kind "DaemonSet" }}
+kind: DaemonSet
+{{- end }}
 metadata:
   name: {{ include "mailu.fullname" . }}-front
 spec:
@@ -14,7 +18,18 @@ spec:
     matchLabels:
       app: {{ include "mailu.fullname" . }}
       component: front
+  {{- if eq .Values.front.controller.kind "Deployment" }}
   replicas: 1
+  strategy:
+  {{- else if eq .Values.front.controller.kind "DaemonSet" }}
+  updateStrategy:
+  {{- end }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      {{- if eq .Values.front.controller.kind "Deployment" }}
+      maxSurge: 0
+      {{- end }}
   template:
     metadata:
       labels:
@@ -159,11 +174,6 @@ spec:
             secretName: {{ include "mailu.fullname" . }}-certificates
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 0
 
 ---
 

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -2,7 +2,7 @@
 
 {{- $clusterDomain := default "cluster.local" .Values.clusterDomain}}
 apiVersion: apps/v1
-kind: {{- required "front.controller.kind" .Values.front.controller.kind "Deployment" }}
+kind: {{ required "front.controller.kind" .Values.front.controller.kind }}
 metadata:
   name: {{ include "mailu.fullname" . }}-front
 spec:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -111,6 +111,9 @@ front:
     limits:
       memory: 200Mi
       cpu: 200m
+  # Deployment or DaemonSet
+  controller:
+    kind: Deployment
 
 admin:
   # logLevel: WARNING


### PR DESCRIPTION
This fixes #46

It introduces a variable `front.controller.kind` which can be `Deployment` (default) or `DaemonSet`.

## Deployment of DaemonSet for front nginx pod(s)

Depending on your environment you might want to shedule "only one pod" (`Deployment`) or "one pod per node" (`DaemonSet`) for the `front` nginx pod(s).

A `DaemonSet` can e.g. be usefull if you have multiple DNS entries / IPs in your MX record and want `front` to be reachable on every IP.


