### PR TITLE
Support podAnnotations on the admin pod

### DIFF
--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app: {{ include "mailu.fullname" . }}
         component: admin
+      {{- with .Values.admin.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -125,6 +125,7 @@ admin:
     limits:
       memory: 500Mi
       cpu: 500m
+  podAnnotations: {}
 
 redis:
   image:


### PR DESCRIPTION
At least one pod should be able to get pod annotations in order to allow utilities like Velero identify the 'data' persistent volume for backup (Velero reads pod annotations to discover backup requests)

Pod annotations for ALL pods may be superfluous and may make the chart values more complex unnecessarily so I didn't add the podAnnotations for all of them.