### PR TITLE
Dovecot made optional

### DIFF
--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -1,5 +1,7 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/imap.yaml
 
+{{- if .Values.dovecot.enabled }}
+
 {{ if .Capabilities.APIVersions.Has "apps/v1/Deployment" }}
 apiVersion: apps/v1
 {{ else }}
@@ -146,3 +148,5 @@ spec:
   - name: sieve
     port: 4190
     protocol: TCP
+
+{{ end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -153,6 +153,7 @@ postfix:
       cpu: 500m
 
 dovecot:
+  enabled: true
   # logLevel: WARNING
   image:
     repository: mailu/dovecot


### PR DESCRIPTION
Not everyone may need Dovecot (IMAP services), so this component should be possible to disable.

For example, in my use-case, I only need to be able to receive emails on some domains, have some mail aliases and need to be able to send emails via SMTP.