### PR TITLE
Fix bug with roundcube and external mysql database

### DIFF
--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -64,8 +64,9 @@ spec:
           - name: ROUNDCUBE_DB_HOST
             {{- if .Values.database.mysql.host }}
             value: {{ .Values.database.mysql.host }}
-            {{- end }}
+            {{- else }}
             value: {{ include "mailu.fullname" . }}-mysql
+            {{- end }}
           {{- else if eq .Values.database.roundcubeType "postgresql" }}
           - name: ROUNDCUBE_DB_FLAVOR
             value: postgresql


### PR DESCRIPTION
It is currently impossible to specify an external mysql database with roundcube enabled, as the chart will always take the internal database hostname (missing else statement in roundcube.yaml template)