### PR TITLE
Allow an optional public-facing service to serve the internet (if desired)

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.0
+version: 0.1.1
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 * a working HTTP/HTTPS ingress controller such as nginx or traefik
-* cert-manager v0.12 or higher installed and configured (including a working cert issuer).  
+* cert-manager v0.12 or higher installed and configured (including a working cert issuer).
 * A node which has a public reachable IP, static address because mail service binds directly to the node's IP
 * A hosting service that allows inbound and outbound traffic on port 25.
 
@@ -65,6 +65,10 @@
 | `database.type`                   | type of database used for mailu      | `sqlite`                                  |
 | `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
 | `database.mysql.*`                | mysql specific settings, see below   | not set                                   |
+| `external_services.enabled`       | enable the public services load balancer   | `false`                             |
+| `external_services.annotations`   | annotation(s) to add to the LB (e.g. for External DNS). See the values.yaml for examples   | not set                                   |
+| `external_services.services`                | list of ports (as required for a service definition) to add to the LB definition. See the values.yaml for examples   | not set                                   |
+
 
 ### Example values.yaml to get started
 
@@ -122,32 +126,32 @@ A `DaemonSet` can e.g. be usefull if you have multiple DNS entries / IPs in your
 
 The default ingress is handled externally. In some situations, this is problematic, such as when webmail should be accessible
  on the same address as the exposed ports. Kubernetes services cannot provide such capabilities without vendor-specific annotations.
- 
+
 By setting `ingress.externalIngress` to false, the internal NGINX instance provided by `front` will configure TLS according to
- `ingress.tlsFlavor` and redirect `http` scheme connections to `https`. 
- 
+ `ingress.tlsFlavor` and redirect `http` scheme connections to `https`.
+
  CAUTION: This configuration exposes `/admin` to all clients with access to the web UI.
 
 ## Database
 
-By default both, Mailu and RoundCube uses an embedded SQLite database. 
+By default both, Mailu and RoundCube uses an embedded SQLite database.
 
 The chart allows to use an embedded MySQL or external MySQL or PostgreSQL databases instead. It can be controlled by the following values:
 
 ### MySQL / MariaDB
 
-In the sub-sections, we we use the reference "MySQL", it is meant for any MySQL-compatible database system (like MariaDB). 
+In the sub-sections, we we use the reference "MySQL", it is meant for any MySQL-compatible database system (like MariaDB).
 
 #### Using MySQL for Mailu
 
 Set ``database.type`` to ``mysql``.
- 
+
 The ``database.mysql.database``, ``database.mysql.user``, and ``database.mysql.password`` variables must also be set.
 
 ### Using MySQL for RoundCube
 
 Set ``database.roundcubeType`` to ``mysql``.
- 
+
 The ``database.mysql.roundcubeDatabase``, ``database.mysql.roundcubeUser``, and ``database.mysql.roundcubePassword`` variables must also be set.
 
 ### Using the internal MySQL database
@@ -171,11 +175,11 @@ The chart does not support different PostgreSQL hosts for Mailu and RoundCube. U
 #### Using PostgreSQL for Mailu
 
 Set ``database.type`` to ``postgresql``.
- 
+
 The ``database.postgresql.database``, ``database.postgresql.user``, and ``database.postgresql.password`` chart values must also be set.
 
 #### Using Postgresql for Roundcube
 
 Set ``database.roundcubeType`` to ``postgresql``.
- 
+
 The``database.postgresql.roundcubeDatabase``, ``database.postgresql.roundcubeUser``, and ``database.postgresql.roundcubePassword`` must also be set.

--- a/mailu/templates/public_service.yaml
+++ b/mailu/templates/public_service.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.external_services.enabled true }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailu-external
+  labels:
+    app: mailu
+{{- if .Values.external_services.annotations }}
+  annotations:
+{{ toYaml .Values.external_services.annotations | indent 4 }}
+{{- end }}
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app: mailu
+    component: front
+{{- if .Values.external_services.services }}
+  ports:
+{{ toYaml .Values.external_services.services | indent 4 }}
+{{- end }}
+{{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -74,6 +74,46 @@ external_relay: {}
 #    username: username
 #    password: SECRET
 
+# Which (if any) services to expose to the internet
+# If this is not enabled, only webmail is exposed via the
+# main domain
+external_services:
+  enabled: false
+  annotations: {}
+      ## If you're using AWS, use nlb to preserve IP
+      # service.beta.kubernetes.io/aws-load-balancer-type: nlb
+      ## If you have external-dns installed, you can use this to make a DNS
+      ## entry. This DNS entry will be what you use to configure your clients to
+      # external-dns.alpha.kubernetes.io/hostname: relay.domain
+  services: {}
+  # - name: pop3
+  #   port: 110
+  #   protocol: TCP
+  # - name: pop3s
+  #   port: 995
+  #   protocol: TCP
+  # - name: imap
+  #   port: 143
+  #   protocol: TCP
+  # - name: imaps
+  #   port: 993
+  #   protocol: TCP
+  # - name: smtp
+  #   port: 25
+  #   protocol: TCP
+  # - name: smtps
+  #   port: 465
+  #   protocol: TCP
+  # - name: smtpd
+  #   port: 587
+  #   protocol: TCP
+  # - name: smtp-auth
+  #   port: 10025
+  #   protocol: TCP
+  # - name: imap-auth
+  #   port: 10143
+  #   protocol: TCP
+
 persistence:
   size: 100Gi
   accessMode: ReadWriteOnce


### PR DESCRIPTION
The chart, by default exposes only the webmail/admin interface, but does not expose any of the MTA services (POP, IMAP, SMTP, etc.)

This is fine if mailu is only going to serve requests from within the cluster, but if you want mailu to serve as a mail server to traffic from the internet, those ports need to be opened.

This PR will create an optional service and make whichever desired ports open to the internet to allow them to be reached by relay hosts, or tester tools like mxtoolbox.

For example, to enable an AWS ELB on `relay.domain.com`, using External DNS to setup the DNS entries, and only allow SMTP on port 25, this would be the required block in the `values.yaml` file:

```
external_services:
  enabled: true
  annotations: 
      service.beta.kubernetes.io/aws-load-balancer-type: nlb
      external-dns.alpha.kubernetes.io/hostname: relay.domain.com
  services: 
   - name: smtp
     port: 25
     protocol: TCP
```