### PR TITLE
Step on #39: Allow for merged pod containing both rspamd and admin

### DIFF
--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
       - name: admin
         image: {{ .Values.admin.image.repository }}:{{ default .Values.mailuVersion .Values.admin.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: admin

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: clamav
         image: {{ .Values.clamav.image.repository }}:{{ default .Values.mailuVersion .Values.clamav.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: clamav

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -103,6 +103,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}-clamav
   {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -107,10 +107,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.clamav.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.clamav.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -68,7 +68,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-clamav{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -94,3 +94,28 @@ spec:
     protocol: TCP
 
 {{- end }}
+
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-clamav
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}

--- a/mailu/templates/combined.yaml
+++ b/mailu/templates/combined.yaml
@@ -212,16 +212,16 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "mailu.claimName" . }}-combined
-  {{- if .Values.persistence.annotations }}
+  {{- if .Values.admin.persistence.annotations }}
   annotations:
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.admin.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.admin.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/combined.yaml
+++ b/mailu/templates/combined.yaml
@@ -1,25 +1,21 @@
-# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/redis.yaml
 
-{{ if not .Values.combineRspamdAdmin  }}
+{{ if .Values.combineRspamdAdmin }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "mailu.fullname" . }}-admin
+  name: {{ include "mailu.fullname" . }}-combined
 spec:
   selector:
     matchLabels:
       app: {{ include "mailu.fullname" . }}
-      component: admin
+      component: combined
   replicas: 1
   template:
     metadata:
       labels:
         app: {{ include "mailu.fullname" . }}
-        component: admin
-      {{- with .Values.admin.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        component: combined
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -107,22 +103,9 @@ spec:
             {{- else }}
             value: {{ include "mailu.fullname" . }}-mysql
             {{- end }}
-          {{- else if eq .Values.database.type "postgresql" }}
-          - name: DB_FLAVOR
-            value: postgresql
-          - name: DB_USER
-            value: {{ required "database.postgresql.user" .Values.database.postgresql.user }}
-          - name: DB_PW
-            value: {{ required "database.postgresql.password" .Values.database.postgresql.password }}
-          - name: DB_NAME
-            value: {{ required "database.postgresql.database" .Values.database.postgresql.database }}
-          - name: DB_HOST
-            {{- if .Values.database.postgresql.host }}
-            value: {{ .Values.database.postgresql.host }}
-            {{- end }}
           {{- else }}
-          value: {{ required "database.type must be one of sqlite/mysql/postgresql" .None }}
-          {{- end }}
+          value: {{ required "database.type must be one of sqlite/mysql" .None }}
+        {{- end }}
         ports:
           - name: http
             containerPort: 80
@@ -145,10 +128,43 @@ spec:
           periodSeconds: 10
           failureThreshold: 1
           timeoutSeconds: 5
+      - name: redis
+        image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: redis
+            mountPath: /data
+        ports:
+          - containerPort: 6379
+            name: redis
+            protocol: TCP
+        {{- with .Values.redis.resources }}
+        resources:
+        {{- .|toYaml|nindent 10}}
+        {{- end }}
+        livenessProbe:
+          exec:
+            command:
+              - /usr/local/bin/redis-cli
+              - info
+              - status
+          periodSeconds: 10
+          failureThreshold: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - /usr/local/bin/redis-cli
+              - info
+              - status
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-combined{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -163,13 +179,54 @@ metadata:
   name: {{ include "mailu.fullname" . }}-admin
   labels:
     app: {{ include "mailu.fullname" . }}
-    component: admin
+    component: combined
 spec:
   selector:
     app: {{ include "mailu.fullname" . }}
-    component: admin
+    component: combined
   ports:
-  - name: http
-    port: 80
+    - name: http
+      port: 80
+      protocol: TCP
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mailu.fullname" . }}-rspamd
+  labels:
+    app: {{ include "mailu.fullname" . }}
+    component: combined
+spec:
+  selector:
+    app: {{ include "mailu.fullname" . }}
+    component: combined
+  ports:
+  - name: redis
+    port: 6379
     protocol: TCP
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-combined
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
 {{ end }}

--- a/mailu/templates/combined.yaml
+++ b/mailu/templates/combined.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
       - name: admin
         image: {{ .Values.admin.image.repository }}:{{ default .Values.mailuVersion .Values.admin.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: admin
@@ -130,7 +130,7 @@ spec:
           timeoutSeconds: 5
       - name: rspamd
         image: {{ .Values.rspamd.image.repository }}:{{ default .Values.mailuVersion .Values.rspamd.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: rspamd

--- a/mailu/templates/combined.yaml
+++ b/mailu/templates/combined.yaml
@@ -225,7 +225,7 @@ spec:
     app: {{ include "mailu.fullname" . }}
     component: combined
   ports:
-  - name: redis
+  - name: rspamd
     port: 6379
     protocol: TCP
 

--- a/mailu/templates/combined.yaml
+++ b/mailu/templates/combined.yaml
@@ -128,38 +128,60 @@ spec:
           periodSeconds: 10
           failureThreshold: 1
           timeoutSeconds: 5
-      - name: redis
-        image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+      - name: rspamd
+        image: {{ .Values.rspamd.image.repository }}:{{ default .Values.mailuVersion .Values.rspamd.image.tag }}
         imagePullPolicy: Always
         volumeMounts:
           - name: data
-            subPath: redis
-            mountPath: /data
+            subPath: rspamd
+            mountPath: /var/lib/rspamd
+          - name: data
+            subPath: dkim
+            mountPath: /dkim
+        env:
+          - name: LOG_LEVEL
+            value: {{ default .Values.logLevel .Values.rspamd.logLevel }}
+          - name: FRONT_ADDRESS
+            value: {{ include "mailu.fullname" . }}-front
+          - name: REDIS_ADDRESS
+            value: {{ include "mailu.fullname" . }}-redis
+          {{- if .Values.clamav.enabled }}
+          - name: ANTIVIRUS
+            value: clamav
+          - name: ANTIVIRUS_ADDRESS
+            value: {{ include "mailu.fullname" . }}-clamav:3310
+          {{- else }}
+          - name: ANTIVIRUS
+            value: none
+          - name: ANTIVIRUS_ADDRESS
+            value: localhost
+          {{- end }}
+          - name: SUBNET
+            value: "{{ .Values.subnet }}"
         ports:
-          - containerPort: 6379
-            name: redis
+          - name: rspamd
+            containerPort: 11332
             protocol: TCP
-        {{- with .Values.redis.resources }}
+          - name: rspamd-http
+            containerPort: 11334
+            protocol: TCP
+        {{- with .Values.rspamd.resources }}
         resources:
         {{- .|toYaml|nindent 10}}
         {{- end }}
         livenessProbe:
-          exec:
-            command:
-              - /usr/local/bin/redis-cli
-              - info
-              - status
-          periodSeconds: 10
+          httpGet:
+            path: /
+            port: rspamd-http
+          periodSeconds: 5
           failureThreshold: 30
           timeoutSeconds: 5
         readinessProbe:
-          exec:
-            command:
-              - /usr/local/bin/redis-cli
-              - info
-              - status
+          httpGet:
+            path: /
+            port: rspamd-http
           periodSeconds: 10
-          failureThreshold: 3
+          failureThreshold: 1
           timeoutSeconds: 5
       volumes:
         - name: data

--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -108,7 +108,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-dovecot{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -144,5 +144,30 @@ spec:
   - name: sieve
     port: 4190
     protocol: TCP
+
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-dovecot
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}
 
 {{ end }}

--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: admin
         image: {{ .Values.dovecot.image.repository }}:{{ default .Values.mailuVersion .Values.dovecot.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: dovecotdata

--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -157,10 +157,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.dovecot.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.dovecot.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
       - name: front
         image: {{ .Values.front.image.repository }}:{{ default .Values.mailuVersion .Values.front.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: certs
             mountPath: /certs

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -140,6 +140,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}-mysql
   {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
       - name: mysql
         image: {{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         args:
           - --character-set-server=utf8
           - --skip-character-set-client-handshake

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -144,10 +144,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.mysql.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.mysql.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -103,7 +103,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-mysql{{ end }}
         - name: initscripts
           configMap:
             name: {{ include "mailu.fullname" . }}-mysql-init
@@ -132,4 +132,28 @@ spec:
     port: 3306
     protocol: TCP
 
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-mysql
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}
 {{ end }}

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: postfix
         image: {{ .Values.postfix.image.repository }}:{{ default .Values.mailuVersion .Values.postfix.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - mountPath: /queue
             name: data

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -153,10 +153,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.postfix.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.postfix.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -107,7 +107,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-postfix{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -140,3 +140,28 @@ spec:
   - name: smtp-auth
     port: 10025
     protocol: TCP
+
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-postfix
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -149,6 +149,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}-postfix
   {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:

--- a/mailu/templates/pvc.yaml
+++ b/mailu/templates/pvc.yaml
@@ -11,6 +11,7 @@ metadata:
   name: {{ include "mailu.fullname" . }}-storage
 {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
 {{ toYaml .Values.persistence.annotations | indent 4 }}
 {{- end }}
 spec:
@@ -61,6 +62,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}
 {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
 {{ toYaml .Values.persistence.annotations | indent 4 }}
 {{- end }}
 spec:

--- a/mailu/templates/pvc.yaml
+++ b/mailu/templates/pvc.yaml
@@ -49,6 +49,7 @@ spec:
         {{- end }}
   {{- end }}
 {{- else if not .Values.persistence.existingClaim }}
+{{ if not .Values.combineRspamdAdmin  }}
 ########################################
 ###
 ### Variant: normal volume claim
@@ -76,3 +77,4 @@ spec:
   {{- end }}
   {{- end }}
 {{- end }}
+{{ end }}

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -99,6 +99,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}-redis
   {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -103,10 +103,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.redis.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.redis.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -65,7 +65,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-redis{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -89,3 +89,29 @@ spec:
   - name: redis
     port: 6379
     protocol: TCP
+
+
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-redis
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
       - name: redis
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: redis

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -142,10 +142,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.roundcube.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.roundcube.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -138,6 +138,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}-roundcube
   {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -106,7 +106,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-roundcube{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -130,4 +130,28 @@ spec:
     port: 80
     protocol: TCP
 
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-roundcube
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}
 {{- end }}

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: roundcube
         image: {{ .Values.roundcube.image.repository }}:{{ default .Values.mailuVersion .Values.roundcube.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - mountPath: /data
             name: data

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: rspamd
         image: {{ .Values.rspamd.image.repository }}:{{ default .Values.mailuVersion .Values.rspamd.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - name: data
             subPath: rspamd

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -1,6 +1,7 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/security.yaml
 # (file is split into rspamd.yaml and clamav.yaml)
 
+{{ if not .Values.combineRspamdAdmin  }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -110,3 +111,4 @@ spec:
   - name: rspamd-http
     protocol: TCP
     port: 11334
+{{ end }}

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -62,7 +62,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.claimName" . }}{{ if .Values.combineRspamdAdmin  }}-webdav{{ end }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -86,4 +86,28 @@ spec:
     port: 5232
     protocol: TCP
 
+{{ if .Values.combineRspamdAdmin  }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.claimName" . }}-webdav
+  {{- if .Values.persistence.annotations }}
+  annotations:
+  {{ toYaml .Values.persistence.annotations | indent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{ end }}
 {{- end }}

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: webdav
         image: {{ .Values.webdav.image.repository }}:{{ default .Values.mailuVersion .Values.webdav.image.tag }}
-        imagePullPolicy: Always
+        imagePullPolicy:  {{ default "Always" .Values.imagePullPolicy }}
         volumeMounts:
           - mountPath: /data
             name: data

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -94,6 +94,7 @@ metadata:
   name: {{ include "mailu.claimName" . }}-webdav
   {{- if .Values.persistence.annotations }}
   annotations:
+    helm.sh/resource-policy: "keep"
   {{ toYaml .Values.persistence.annotations | indent 4 }}
   {{- end }}
 spec:

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -98,10 +98,10 @@ metadata:
   {{- end }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ .Values.webdav.persistence.accessMode }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.webdav.persistence.size }}
   {{- if .Values.persistence.storageClass }}
   {{- if (eq "-" .Values.persistence.storageClass) }}
   storageClassName: ""

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -21,6 +21,7 @@
 nameOverride: ""
 fullnameOverride: ""
 clusterDomain: cluster.local
+imagePullPolicy: Always
 
 nodeSelector: {}
 

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -93,6 +93,9 @@ mailuVersion: 1.8
 # default log level. can be overridden globally or per service
 logLevel: WARNING
 
+# Set to true if Redis and Admin containers should run from the same pod to share DKIM mount
+combineRspamdAdmin: false
+
 mail:
   messageSizeLimitInMegabytes: 50
   authRatelimit: 10/minute;1000/hour

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -144,6 +144,9 @@ admin:
     limits:
       memory: 500Mi
       cpu: 500m
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce
   podAnnotations: {}
 
 redis:
@@ -157,6 +160,9 @@ redis:
     limits:
       memory: 300Mi
       cpu: 200m
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce
 
 postfix:
   # logLevel: WARNING
@@ -171,6 +177,9 @@ postfix:
     limits:
       memory: 2Gi
       cpu: 500m
+  persistence:
+    size: 100G
+    accessMode: ReadWriteOnce
 
 dovecot:
   enabled: true
@@ -186,6 +195,9 @@ dovecot:
     limits:
       memory: 500Mi
       cpu: 500m
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce
 
 rspamd:
   # logLevel: WARNING
@@ -200,6 +212,7 @@ rspamd:
     limits:
       memory: 200Mi
       cpu: 200m
+  # shares persistence with admin
 
 clamav:
   enabled: true
@@ -215,6 +228,9 @@ clamav:
     limits:
       memory: 2Gi
       cpu: 1000m
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce
 
 roundcube:
   enabled: true
@@ -230,6 +246,9 @@ roundcube:
     limits:
       memory: 200Mi
       cpu: 200m
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce
 
 
 webdav:
@@ -239,6 +258,9 @@ webdav:
     repository: mailu/radicale
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce
 
 mysql:
   image:
@@ -251,3 +273,6 @@ mysql:
     limits:
       memory: 512Mi
       cpu: 200m
+  persistence:
+    size: 10G
+    accessMode: ReadWriteOnce


### PR DESCRIPTION
This PR allows a deployer to install the chart with 
- `admin` and `rspamd` charts merged, making the `subPath: /dkim` only used by a single pod
- Individual non-shared PVCs for the different pods

It's one step on cleanly allowing the changes in #39 to be realized.