### PR TITLE
Add externalService, which can be use to expose ports directly

### DIFF
--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -132,11 +132,6 @@ spec:
           - name: http
             containerPort: 80
             protocol: TCP
-          {{ if not .Values.ingress.externalIngress }}
-          - name: https
-            containerPort: 443
-            protocol: TCP
-          {{end}}
         {{- with .Values.front.resources }}
         resources:
         {{- .|toYaml|nindent 10}}
@@ -181,38 +176,118 @@ spec:
     app: {{ include "mailu.fullname" . }}
     component: front
   ports:
+    - name: pop3
+      port: 110
+      protocol: TCP
+    - name: pop3s
+      port: 995
+      protocol: TCP
+    - name: imap
+      port: 143
+      protocol: TCP
+    - name: imaps
+      port: 993
+      protocol: TCP
+    - name: smtp
+      port: 25
+      protocol: TCP
+    - name: smtps
+      port: 465
+      protocol: TCP
+    - name: smtpd
+      port: 587
+      protocol: TCP
+    - name: smtp-auth
+      port: 10025
+      protocol: TCP
+    - name: imap-auth
+      port: 10143
+      protocol: TCP
+    - name: http
+      port: 80
+      protocol: TCP
+    {{ if not .Values.ingress.externalIngress }}
+    - name: https
+      port: 443
+      protocol: TCP
+  {{end}}
+
+---
+{{- with .Values.front.externalService }}
+{{- if .enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mailu.fullname" $ }}-front-ext
+  labels:
+    app: {{ include "mailu.fullname" $ }}
+    component: front
+  {{- with .annotations }}
+  annotations:
+{{ . | toYaml | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .type | default "ClusterIP" }}
+  selector:
+    app: {{ include "mailu.fullname" $ }}
+    component: front
+  ports:
+{{- with .pop3 }}
+  {{- if .pop3 }}
   - name: pop3
     port: 110
     protocol: TCP
+  {{- end }}
+  {{- if .pop3s }}
   - name: pop3s
     port: 995
     protocol: TCP
+  {{- end }}
+{{- end }}
+
+{{- with .imap }}
+  {{- if .imap }}
   - name: imap
     port: 143
     protocol: TCP
+  {{- end }}
+  {{- if .imaps }}
   - name: imaps
     port: 993
     protocol: TCP
-  - name: smtp
-    port: 25
-    protocol: TCP
-  - name: smtps
-    port: 465
-    protocol: TCP
-  - name: smtpd
-    port: 587
-    protocol: TCP
-  - name: smtp-auth
-    port: 10025
-    protocol: TCP
+  {{- end }}
   - name: imap-auth
     port: 10143
     protocol: TCP
+{{- end }}
+
+{{- with .smtp }}
+  {{- if .smtp }}
+  - name: smtp
+    port: 25
+    protocol: TCP
+  {{- end }}
+  {{- if .smtps }}
+  - name: smtps
+    port: 465
+    protocol: TCP
+  {{- end }}
+  {{- if .submission }}
+  - name: smtpd
+    port: 587
+    protocol: TCP
+  {{- end }}
+  - name: smtp-auth
+    port: 10025
+    protocol: TCP
+  {{- end }}
+  {{- if not $.Values.ingress.externalIngress }}
   - name: http
     port: 80
     protocol: TCP
-{{ if not .Values.ingress.externalIngress }}
   - name: https
     port: 443
     protocol: TCP
-{{end}}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -112,6 +112,20 @@ ingress:
 
 # Frontend load balancer for non-HTTP(s) services
 front:
+  externalService:
+    enabled: false
+    type: ClusterIP
+    annotations: {}
+    pop3:
+      pop3: false
+      pop3s: true
+    imap:
+      imap: false
+      imaps: true
+    smtp:
+      smtp: true
+      smtps: true
+      submission: true
   # logLevel: WARNING
   image:
     repository: mailu/nginx


### PR DESCRIPTION
This PR adds a second `Service` to the `front` deployment, which allows configuration for its `type` and `annotations`. This can be easily used to publish this service as a `LoadBalancer`.

This service has toggles for all the ports that users might want to expose, and can be used with or without an `externalIngress`.