### PR TITLE
Helm Chart podAnnotations + storageClassName

### DIFF
--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: {{ include "mailu.fullname" . }}
         component: dovecot
+      {{- with .Values.dovecot.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/mailu/templates/pvc.yaml
+++ b/mailu/templates/pvc.yaml
@@ -14,6 +14,7 @@ metadata:
 {{ toYaml .Values.persistence.annotations | indent 4 }}
 {{- end }}
 spec:
+  storageClassName: manual
   accessModes:
     - ReadWriteMany
   volumeName: {{ include "mailu.fullname" . }}-storage
@@ -27,6 +28,7 @@ kind: PersistentVolume
 metadata:
   name: {{ include "mailu.claimName" . }}
 spec:
+  storageClassName: manual
   capacity:
     storage: {{ .Values.persistence.size }}
   accessModes:

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: {{ include "mailu.fullname" . }}
         component: roundcube
+      {{- with .Values.roundcube.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
This PR fix two issue I faces when deploying the helm chart:
1. it sets the name of the storageClass prevent the default one if defined to hijack the provisioning process
2. It allows to set pod annotations for pods that use secrets to retrieve the secrets directly from a vault