### PR TITLE
make Certificate Renew value consistent with Kubernetes API Object

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.2
+version: 0.1.3
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.1
+version: 0.1.2
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/templates/certificate.yaml
+++ b/mailu/templates/certificate.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "mailu.fullname" . }}-certificates
 spec:
   secretName: {{ include "mailu.fullname" . }}-certificates
-  renewBefore: 1440h # 60d
+  renewBefore: 1440h0m0s
   commonName: "{{ first (required "hostname" .Values.hostnames) }}"
   dnsNames:
 {{- range .Values.hostnames }}

--- a/mailu/templates/certificate.yaml
+++ b/mailu/templates/certificate.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "mailu.fullname" . }}-certificates
 spec:
   secretName: {{ include "mailu.fullname" . }}-certificates
+  # re-new certificate when it expires in less than 60 days
   renewBefore: 1440h0m0s
   commonName: "{{ first (required "hostname" .Values.hostnames) }}"
   dnsNames:


### PR DESCRIPTION
While moving from default Helm3 to ArgoCD i experienced, that the value is not consitent with the Kubernetes API Object.
This will result in a faulty state in ArgoCD because the Manifest always differs from the Kubernetes API Object

![Screenshot 2021-06-13 at 18 56 20](https://user-images.githubusercontent.com/7397248/121815937-1461e080-cc79-11eb-9feb-2ecfebba44ba.png)
