### PR TITLE
Remove CertManager Dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Pack chart
         run: |
           ./helm3 package mailu -d gh-pages
-          ./helm3 repo index --url https://mailu.github.io/helm-charts/ gh-pages
+          ./helm3 repo index --url https://adi90x.github.io/helm-charts/ gh-pages
           ( cd gh-pages && ./index.html.sh > index.html )
       - name: Render chart to yamls
         run: |

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [Chart documentation](mailu/README.md)
 
 
-Releases can be found at https://mailu.github.io/helm-charts/
+Releases can be found at https://adi90x.github.io/helm-charts/

--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.3
+version: 0.1.4
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.2
+version: 0.1.3
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -46,7 +46,7 @@
 | `initialAccount.domain`           | Domain part (part after @) for initial admin account | not set                   |
 | `initialAccount.password`         | Password for initial admin account   | not set                                   |
 | `front.controller.kind`           | Use Deployment or DaemonSet for `front` pod(s) | `Deployment`                    |
-| `certmanager.use`                 | Enable the use of CertManager to generate secrets         | `ClusterIssuer`      |
+| `certmanager.enabled`             | Enable the use of CertManager to generate secrets         | `ClusterIssuer`      |
 | `certmanager.issuerType`          | Issuer type for cert manager         | `ClusterIssuer`                           |
 | `certmanager.issuerName`          | Name of a preconfigured cert issuer  | `letsencrypt`                             |
 | `certmanager.apiVersion`          | API-Version for certmanager CRDs     | `cert-manager.io/v1alpha2`                |

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -46,6 +46,7 @@
 | `initialAccount.domain`           | Domain part (part after @) for initial admin account | not set                   |
 | `initialAccount.password`         | Password for initial admin account   | not set                                   |
 | `front.controller.kind`           | Use Deployment or DaemonSet for `front` pod(s) | `Deployment`                    |
+| `certmanager.use`                 | Enable the use of CertManager to generate secrets         | `ClusterIssuer`      |
 | `certmanager.issuerType`          | Issuer type for cert manager         | `ClusterIssuer`                           |
 | `certmanager.issuerName`          | Name of a preconfigured cert issuer  | `letsencrypt`                             |
 | `certmanager.apiVersion`          | API-Version for certmanager CRDs     | `cert-manager.io/v1alpha2`                |
@@ -130,6 +131,14 @@ By setting `ingress.externalIngress` to false, the internal NGINX instance provi
  `ingress.tlsFlavor` and redirect `http` scheme connections to `https`. 
  
  CAUTION: This configuration exposes `/admin` to all clients with access to the web UI.
+
+## CertManager
+
+The default logic is to use CertManager to generate certificate for Mailu.
+
+In some configuration you want to handle certificate generation and update another way, use `certmanager.use=false` to avoid the use of the CRD.
+
+You will have to create and keep up-to-date your TLS keys. At the moment, this chart is looking for it under the `"mailu.fullname"-certificates` name in the namespace.
 
 ## Database
 

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 * a working HTTP/HTTPS ingress controller such as nginx or traefik
-* cert-manager v0.12 or higher installed and configured (including a working cert issuer).  
+* cert-manager v0.12 or higher installed and configured (including a working cert issuer).( Otherwise you will need to handle it by yourself and provide the secret to Mailu )   
 * A node which has a public reachable IP, static address because mail service binds directly to the node's IP
 * A hosting service that allows inbound and outbound traffic on port 25.
 

--- a/mailu/templates/certificate.yaml
+++ b/mailu/templates/certificate.yaml
@@ -1,6 +1,6 @@
 # This is the definition of the required ssl certificate for the mail system
 # It will be issued by cert-manager
-{{ if .Values.ingress.certmanager.enabled }}
+{{ if .Values.certmanager.enabled }}
 
 apiVersion: {{ .Values.certmanager.apiVersion }}
 kind: Certificate

--- a/mailu/templates/certificate.yaml
+++ b/mailu/templates/certificate.yaml
@@ -1,6 +1,6 @@
 # This is the definition of the required ssl certificate for the mail system
 # It will be issued by cert-manager
-
+{{ if .Values.ingress.certmanager.use }}
 apiVersion: {{ .Values.certmanager.apiVersion }}
 kind: Certificate
 metadata:
@@ -16,3 +16,4 @@ spec:
   issuerRef:
     kind: {{ .Values.certmanager.issuerType }}
     name: {{ .Values.certmanager.issuerName }}
+{{ end }}    

--- a/mailu/templates/certificate.yaml
+++ b/mailu/templates/certificate.yaml
@@ -1,6 +1,7 @@
 # This is the definition of the required ssl certificate for the mail system
 # It will be issued by cert-manager
-{{ if .Values.ingress.certmanager.use }}
+{{ if .Values.ingress.certmanager.enabled }}
+
 apiVersion: {{ .Values.certmanager.apiVersion }}
 kind: Certificate
 metadata:
@@ -16,4 +17,5 @@ spec:
   issuerRef:
     kind: {{ .Values.certmanager.issuerType }}
     name: {{ .Values.certmanager.issuerName }}
-{{ end }}    
+    
+{{- end }}   

--- a/mailu/templates/fetchmail.yaml
+++ b/mailu/templates/fetchmail.yaml
@@ -46,7 +46,7 @@ spec:
           # LOG_LEVEL is called DEBUG in https://github.com/Mailu/Mailu/blob/master/optional/fetchmail/fetchmail.py#L98
           # and will only give debug output if value is True
           - name: DEBUG
-          {{- if (eq .Values.logLevel "DEBUG") or (eq .Values.fetchmail.logLevel "DEBUG") }}
+          {{- if or (eq .Values.logLevel "DEBUG") (eq .Values.fetchmail.logLevel "DEBUG") }}
             value: "True"
           {{- else }}
             value: "False"

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -28,7 +28,7 @@ spec:
         app: {{ include "mailu.fullname" . }}
         component: front
     spec:
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.front.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -2,7 +2,7 @@
 
 {{- $fullname := (include "mailu.fullname" .) }}
 {{ if .Values.ingress.externalIngress }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullname }}-ingress

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -128,7 +128,8 @@ front:
   # Deployment or DaemonSet
   controller:
     kind: Deployment
-
+  # nodeSelector: 
+  
 admin:
   # logLevel: WARNING
   image:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -128,7 +128,7 @@ front:
   # Deployment or DaemonSet
   controller:
     kind: Deployment
-  # nodeSelector: 
+  nodeSelector: {}
   
 admin:
   # logLevel: WARNING

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -99,7 +99,7 @@ mail:
 
 # certmanager settings
 certmanager:
-  use: true
+  enabled: true
   issuerType: ClusterIssuer
   issuerName: letsencrypt
   apiVersion: cert-manager.io/v1alpha2

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -99,6 +99,7 @@ mail:
 
 # certmanager settings
 certmanager:
+  use: true
   issuerType: ClusterIssuer
   issuerName: letsencrypt
   apiVersion: cert-manager.io/v1alpha2


### PR DESCRIPTION
Hello, 

Very small PR to remove dependency to CertManager.
Give a way to user to use the chart without having certmanager CRD.

For example, you can then use Mailu with  [Kube-Active-Proxy ](https://gitlab.com/adi90x/kube-active-proxy) an all in one reverse proxy for Kubernete

Regards,
Adrien
