### PR TITLE
Change API from 'networking.k8s.io/v1beta1' to 'networking.k8s.io/v1'

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.2
+version: 0.1.4
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -2,7 +2,7 @@
 
 {{- $fullname := (include "mailu.fullname" .) }}
 {{ if .Values.ingress.externalIngress }}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullname }}-ingress
@@ -27,7 +27,9 @@ spec:
       paths:
       - path: "/"
         backend:
-          serviceName: {{ $fullname }}-front
-          servicePort: 80
+          service:
+            name: {{ $fullname }}-front
+            port: 80
+        pathType: ImplementationSpecific
 {{- end }}
 {{ end }}


### PR DESCRIPTION
    The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of kubernetes v1.22.
    The networking.k8s.io/v1 API version, available since kubernetes v1.19.
    
    Updated manifest from use API 'networking.k8s.io/v1beta1' to use 'networking.k8s.io/v1'
    Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/ -> Ingress
