### PR TITLE
Change update strategy to recreate

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.8"
 description: Mailu mail system
 name: mailu
-version: 0.1.2
+version: 0.1.3
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -109,10 +109,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "mailu.claimName" . }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 0
+    type: Recreate
 
 ---
 


### PR DESCRIPTION
When using rollingupdate, postfix remains stuck. Setting the strategy to Recreate make it start normally.