### PR TITLE
fix ingress service port

### DIFF
--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -29,7 +29,8 @@ spec:
         backend:
           service:
             name: {{ $fullname }}-front
-            port: 80
+            port: 
+              number: 80
         pathType: ImplementationSpecific
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Hi, the changes in https://github.com/Mailu/helm-charts/pull/106 are invalid: 
`error validating data: ValidationError(Ingress.spec.rules[0].http.paths[0].backend.service.port): invalid type for io.k8s.api.networking.v1.ServiceBackendPort: got "integer", expected "map"`