### PR TITLE
Add ADMIN_ADDRESS to rspamd

### DIFF
--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -55,6 +55,8 @@ spec:
             value: {{ default .Values.logLevel .Values.rspamd.logLevel }}
           - name: FRONT_ADDRESS
             value: {{ include "mailu.fullname" . }}-front
+          - name: ADMIN_ADDRESS
+            value: {{ include "mailu.fullname" . }}-admin
           - name: REDIS_ADDRESS
             value: {{ include "mailu.fullname" . }}-redis
           {{- if .Values.clamav.enabled }}


### PR DESCRIPTION
Since rspamd's start.py now uses ADMIN_ADDRESS, it should be added as an env variable accordingly. Otherwise the pod won't start properly
See https://github.com/Mailu/Mailu/blob/master/core/rspamd/start.py#L14