### PR TITLE
feat: single PVC per app

### DIFF
--- a/mailu/templates/_helpers.tpl
+++ b/mailu/templates/_helpers.tpl
@@ -56,3 +56,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{ define "mailu.rspamdClamavClaimName"}}
+{{- .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.rspamd_clamav_persistence.claimNameOverride | default (printf "%s-rspamd-clamav" (include "mailu.fullname" .)) }}
+{{- end }}

--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -1,5 +1,8 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin.yaml
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.admin.persistence.claimNameOverride | default (printf "%s-admin" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -169,7 +172,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -181,6 +184,29 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+
+
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.admin.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.admin.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.admin.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.admin.persistence.size }}
+  {{- if .Values.admin.persistence.storageClass }}
+  storageClassName: {{ .Values.admin.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -23,7 +23,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.clamav.afffinity | default .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -89,7 +89,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.rspamdClamavClaimName" . }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:

--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -2,6 +2,9 @@
 
 {{- if .Values.dovecot.enabled }}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.dovecot.persistence.claimNameOverride | default (printf "%s-dovecot" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -136,7 +139,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.dovecot.overrides }}
         - name: overrides
           configMap:
@@ -153,6 +156,29 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+
+
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.dovecot.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.dovecot.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.dovecot.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.dovecot.persistence.size }}
+  {{- if .Values.dovecot.persistence.storageClass }}
+  storageClassName: {{ .Values.dovecot.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/templates/fetchmail.yaml
+++ b/mailu/templates/fetchmail.yaml
@@ -2,6 +2,9 @@
 
 {{- if .Values.fetchmail.enabled }}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.fetchmail.persistence.claimNameOverride | default (printf "%s-fetchmail" (include "mailu.fullname" .)) }}
+
 {{ if .Capabilities.APIVersions.Has "apps/v1/Deployment" }}
 apiVersion: apps/v1
 {{ else }}
@@ -76,7 +79,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -88,5 +91,28 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+
+
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.fetchmail.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.fetchmail.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.fetchmail.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.fetchmail.persistence.size }}
+  {{- if .Values.fetchmail.persistence.storageClass }}
+  storageClassName: {{ .Values.fetchmail.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 {{- end }}

--- a/mailu/templates/mysql.yaml
+++ b/mailu/templates/mysql.yaml
@@ -1,5 +1,8 @@
 {{ if and (or (eq .Values.database.type "mysql") (eq .Values.database.roundcubeType "mysql")) (not .Values.database.mysql.host) }}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.mysql.persistence.claimNameOverride | default (printf "%s-mysql" (include "mailu.fullname" .)) }}
+
 {{ if (eq .Values.database.roundcubeType "mysql") }}
 apiVersion: v1
 kind: ConfigMap
@@ -127,7 +130,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         - name: initscripts
           configMap:
             name: {{ include "mailu.fullname" . }}-mysql-init
@@ -143,6 +146,29 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0
+
+
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.mysql.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.mysql.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.mysql.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.mysql.persistence.size }}
+  {{- if .Values.mysql.persistence.storageClass }}
+  storageClassName: {{ .Values.mysql.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -1,5 +1,8 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin.yaml
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.postfix.persistence.claimNameOverride | default (printf "%s-postfix" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -131,7 +134,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -140,6 +143,29 @@ spec:
         {{- end }}
   strategy:
     type: Recreate
+
+
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.postfix.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.postfix.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.postfix.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.postfix.persistence.size }}
+  {{- if .Values.postfix.persistence.storageClass }}
+  storageClassName: {{ .Values.postfix.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -1,5 +1,8 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/redis.yaml
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.redis.persistence.claimNameOverride | default (printf "%s-redis" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -89,7 +92,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -101,6 +104,29 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+
+
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.redis.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.redis.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.redis.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+  {{- if .Values.redis.persistence.storageClass }}
+  storageClassName: {{ .Values.redis.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -2,6 +2,9 @@
 
 {{- if .Values.roundcube.enabled }}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.roundcube.persistence.claimNameOverride | default (printf "%s-roundcube" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -129,7 +132,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -142,7 +145,30 @@ spec:
       maxUnavailable: 0
       maxSurge: 1
 
+{{- if not .Values.persistence.single_pvc }}
 ---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.roundcube.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.roundcube.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.roundcube.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.roundcube.persistence.size }}
+  {{- if .Values.roundcube.persistence.storageClass }}
+  storageClassName: {{ .Values.roundcube.persistence.storageClass }}
+  {{- end }}
+{{- end }}
+
+---
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/mailu/templates/rspamd-clamav-pvc.yml
+++ b/mailu/templates/rspamd-clamav-pvc.yml
@@ -1,0 +1,21 @@
+{{- if not .Values.persistence.single_pvc }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "mailu.rspamdClamavClaimName" . }}
+{{- if .Values.rspamd_clamav_persistence.annotations }}
+  annotations:
+{{ toYaml .Values.rspamd_clamav_persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.rspamd_clamav_persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.rspamd_clamav_persistence.size }}
+  {{- if .Values.rspamd_clamav_persistence.storageClass }}
+  storageClassName: {{ .Values.rspamd_clamav_persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -21,7 +21,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.rspamd.affinity | default .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -111,7 +111,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ include "mailu.rspamdClamavClaimName" . }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:

--- a/mailu/templates/single-pvc.yaml
+++ b/mailu/templates/single-pvc.yaml
@@ -1,5 +1,6 @@
 # This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/pvc.yaml
 
+{{- if .Values.persistence.single_pvc }}
 {{- if .Values.persistence.hostPath }}
 ########################################
 ###
@@ -75,4 +76,5 @@ spec:
   storageClassName: {{ .Values.persistence.storageClass }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -2,6 +2,9 @@
 
 {{- if .Values.webdav.enabled }}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.webdav.persistence.claimNameOverride | default (printf "%s-webdav" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +87,7 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "mailu.claimName" . }}
+            claimName: {{ $claimName }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -97,7 +100,30 @@ spec:
       maxUnavailable: 0
       maxSurge: 1
 
+
+{{- if not .Values.persistence.single_pvc }}
 ---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.webdav.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.webdav.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.webdav.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.webdav.persistence.size }}
+  {{- if .Values.webdav.persistence.storageClass }}
+  storageClassName: {{ .Values.webdav.persistence.storageClass }}
+  {{- end }}
+{{- end }}
+---
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/mailu/test.yml
+++ b/mailu/test.yml
@@ -1,0 +1,1130 @@
+---
+# Source: mailu/templates/admin.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-admin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/clamav.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-clamav
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/dovecot.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-dovecot
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/postfix.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-postfix
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/redis.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/roundcube.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-roundcube
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/rspamd.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  RELEASE-NAME-mailu-rspamd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+---
+# Source: mailu/templates/admin.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-admin
+  labels:
+    app: RELEASE-NAME-mailu
+    component: admin
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: admin
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+# Source: mailu/templates/clamav.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-clamav
+  labels:
+    app: RELEASE-NAME-mailu
+    component: clamav
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: clamav
+  ports:
+  - name: clamav
+    port: 3310
+    protocol: TCP
+---
+# Source: mailu/templates/dovecot.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-dovecot
+  labels:
+    app: RELEASE-NAME-mailu
+    component: dovecot
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: dovecot
+  ports:
+  - name: imap-auth
+    port: 2102
+    protocol: TCP
+  - name: imap-transport
+    port: 2525
+    protocol: TCP
+  - name: imap-default
+    port: 143
+    protocol: TCP
+  - name: pop3
+    port: 110
+    protocol: TCP
+  - name: sieve
+    port: 4190
+    protocol: TCP
+---
+# Source: mailu/templates/front.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-front
+  labels:
+    app: RELEASE-NAME-mailu
+    component: front
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: front
+  ports:
+  - name: pop3
+    port: 110
+    protocol: TCP
+  - name: pop3s
+    port: 995
+    protocol: TCP
+  - name: imap
+    port: 143
+    protocol: TCP
+  - name: imaps
+    port: 993
+    protocol: TCP
+  - name: smtp
+    port: 25
+    protocol: TCP
+  - name: smtps
+    port: 465
+    protocol: TCP
+  - name: smtpd
+    port: 587
+    protocol: TCP
+  - name: smtp-auth
+    port: 10025
+    protocol: TCP
+  - name: imap-auth
+    port: 10143
+    protocol: TCP
+  - name: http
+    port: 80
+    protocol: TCP
+---
+# Source: mailu/templates/postfix.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-postfix
+  labels:
+    app: RELEASE-NAME-mailu
+    component: postfix
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: postfix
+  ports:
+  - name: smtp
+    port: 25
+    protocol: TCP
+  - name: smtp-ssl
+    port: 465
+    protocol: TCP
+  - name: smtp-starttls
+    port: 587
+    protocol: TCP
+  - name: smtp-auth
+    port: 10025
+    protocol: TCP
+---
+# Source: mailu/templates/redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-redis
+  labels:
+    app: RELEASE-NAME-mailu
+    component: redis
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: redis
+  ports:
+  - name: redis
+    port: 6379
+    protocol: TCP
+---
+# Source: mailu/templates/roundcube.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-roundcube
+  labels:
+    app: RELEASE-NAME-mailu
+    component: roundcube
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: roundcube
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+---
+# Source: mailu/templates/rspamd.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: RELEASE-NAME-mailu-rspamd
+  labels:
+    app: RELEASE-NAME-mailu
+    component: rspamd
+spec:
+  selector:
+    app: RELEASE-NAME-mailu
+    component: rspamd
+  ports:
+  - name: rspamd
+    port: 11332
+    protocol: TCP
+  - name: rspamd-http
+    protocol: TCP
+    port: 11334
+---
+# Source: mailu/templates/admin.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-admin
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: admin
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: admin
+    spec:
+      containers:
+      - name: admin
+        image: mailu/admin:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: admin
+            mountPath: /data
+          - name: data
+            mountPath: /dkim
+            subPath: dkim
+        env:
+          - name: LOG_LEVEL
+            value: WARNING
+          - name: QUOTA_STORAGE_URL
+            value: redis://RELEASE-NAME-mailu-redis/1
+          - name: RATELIMIT_STORAGE_URL
+            value: redis://RELEASE-NAME-mailu-redis/2
+          - name: DOMAIN
+            value: "example.com"
+          - name: HOSTNAMES
+            value: "mail.example.com,imap.example.com"
+          - name: IMAP_ADDRESS
+            value: RELEASE-NAME-mailu-dovecot.default
+          - name: POP3_ADDRESS
+            value: RELEASE-NAME-mailu-dovecot.default
+          - name: SMTP_ADDRESS
+            value: RELEASE-NAME-mailu-postfix.default
+          - name: AUTHSMTP_ADDRESS
+            value: RELEASE-NAME-mailu-postfix.default
+          - name: REDIS_ADDRESS
+            value: RELEASE-NAME-mailu-redis.default
+          - name: WEBMAIL
+            value: none
+          - name: WEBMAIL_ADDRESS
+            value: localhost
+          - name: FRONT_ADDRESS
+            value: RELEASE-NAME-mailu-front.default
+          - name: RECIPIENT_DELIMITER
+            value: +
+          - name: SUBNET
+            value: 10.42.0.0/16
+          - name: PASSWORD_SCHEME
+            value: "PBKDF2"
+          - name: SECRET_KEY
+            value: "chang3m3!"
+          - name: AUTH_RATELIMIT
+            value: "10/minute;1000/hour"
+          - name: DB_FLAVOR
+            value: sqlite
+        ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+        startupProbe:
+          httpGet:
+            path: /ui/login
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 30 
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /ui/login
+            port: http
+          periodSeconds: 10
+          failureThreshold: 3
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ui/login
+            port: http
+          periodSeconds: 10
+          failureThreshold: 1
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-admin
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+# Source: mailu/templates/clamav.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/security.yaml
+# (file is split into rspamd.yaml and clamav.yaml)
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-clamav
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: clamav
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: clamav
+    spec:
+      containers:
+      - name: clamav
+        image: mailu/clamav:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: clamav
+            mountPath: /data
+        env:
+          - name: LOG_LEVEL
+            value: WARNING
+        ports:
+          - name: clamav
+            containerPort: 3310
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 2Gi
+          requests:
+            cpu: 1000m
+            memory: 1Gi
+        startupProbe:
+          exec:
+            command:
+              - /health.sh
+          periodSeconds:  10 
+          failureThreshold: 60 
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+              - /health.sh
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - /health.sh
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-clamav
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+# Source: mailu/templates/dovecot.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/imap.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-dovecot
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: dovecot
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: dovecot
+    spec:
+      containers:
+      - name: admin
+        image: mailu/dovecot:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: dovecotdata
+            mountPath: /data
+          - name: data
+            mountPath: /mail
+            subPath: dovecotmail
+        env:
+          - name: LOG_LEVEL
+            value: WARNING
+          - name: FRONT_ADDRESS
+            value: RELEASE-NAME-mailu-front
+          - name: ADMIN_ADDRESS
+            value: RELEASE-NAME-mailu-admin
+          - name: ANTISPAM_WEBUI_ADDRESS
+            value: RELEASE-NAME-mailu-rspamd:11334
+          - name: POSTMASTER
+            value: postmaster
+          - name: DOMAIN
+            value: "example.com"
+          - name: HOSTNAMES
+            value: "mail.example.com,imap.example.com"
+          - name: RECIPIENT_DELIMITER
+            value: +
+          # TODO: COMPRESSION / COMPRESS_LEVEL -> documentation?
+
+          # TODO: next entries should be removed when https://github.com/Mailu/Mailu/issues/1112 is fixed
+          - name: REDIS_ADDRESS
+            value: RELEASE-NAME-mailu-redis
+          - name: WEBMAIL
+            value: none
+          - name: SECRET_KEY
+            value: "chang3m3!"
+        ports:
+          - name: auth
+            containerPort: 2102
+            protocol: TCP
+          - name: lmtp
+            containerPort: 2525
+            protocol: TCP
+          - name: imap
+            containerPort: 143
+            protocol: TCP
+          - name: pop3
+            containerPort: 110
+            protocol: TCP
+          - name: sieve
+            containerPort: 4190
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 500m
+            memory: 500Mi
+        startupProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'echo QUIT|nc localhost 110|grep "Dovecot ready."'
+          periodSeconds:  10 
+          failureThreshold: 30 
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'echo QUIT|nc localhost 110|grep "Dovecot ready."'
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'echo QUIT|nc localhost 110|grep "Dovecot ready."'
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-dovecot
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+# Source: mailu/templates/front.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/front.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-front
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: front
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: front
+    spec:
+      containers:
+      - name: front
+        image: mailu/nginx:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: certs
+            mountPath: /certs
+        env:
+          - name: LOG_LEVEL
+            value: WARNING
+          - name: KUBERNETES_INGRESS
+            value: "true"
+          - name: TLS_FLAVOR
+            value: cert
+          - name: HOSTNAMES
+            value: "mail.example.com,imap.example.com"
+          - name: ADMIN_ADDRESS
+            value: RELEASE-NAME-mailu-admin.default.svc.cluster.local
+          - name: ANTISPAM_WEBUI_ADDRESS
+            value: RELEASE-NAME-mailu-rspamd.default.svc.cluster.local:11334
+          - name: WEBMAIL
+            value: roundcube
+          - name: WEBMAIL_ADDRESS
+            value: RELEASE-NAME-mailu-roundcube.default.svc.cluster.local
+          - name: MESSAGE_SIZE_LIMIT
+            value: "52428800"
+          - name: WEB_WEBMAIL
+            value: "/"
+          - name: WEBDAV
+            value: none
+          - name: WEBDAV_ADDRESS
+            value: localhost
+          - name: ADMIN
+            value: "true"
+          - name: WEB_ADMIN
+            value: "/admin"
+          - name: SUBNET
+            value: 10.42.0.0/16
+        ports:
+          - name: pop3
+            protocol: TCP
+            containerPort: 110
+            hostPort: 110
+          - name: pop3s
+            protocol: TCP
+            containerPort: 995
+            hostPort: 995
+          - name: imap
+            protocol: TCP
+            containerPort: 143
+            hostPort: 143
+          - name: imaps
+            protocol: TCP
+            containerPort: 993
+            hostPort: 993
+          - name: smtp
+            protocol: TCP
+            containerPort: 25
+            hostPort: 25
+          - name: smtps
+            protocol: TCP
+            containerPort: 465
+            hostPort: 465
+          - name: smtp-auth
+            protocol: TCP
+            containerPort: 10025
+          - name: imap-auth
+            protocol: TCP
+            containerPort: 10143
+          - name: smtpd
+            protocol: TCP
+            containerPort: 587
+            hostPort: 587
+          - name: auth
+            containerPort: 8000
+            protocol: TCP
+          - name: http
+            containerPort: 80
+            protocol: TCP
+          
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 30 
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: certs
+          secret:
+            items:
+              - key: tls.crt
+                path: cert.pem
+              - key: tls.key
+                path: key.pem
+            secretName: RELEASE-NAME-mailu-certificates
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+---
+# Source: mailu/templates/postfix.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-postfix
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: postfix
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: postfix
+    spec:
+      containers:
+      - name: postfix
+        image: mailu/postfix:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - mountPath: /queue
+            name: data
+            subPath: mailqueue
+        env:
+          - name: LOG_LEVEL
+            value: WARNING
+          - name: REJECT_UNLISTED_RECIPIENT
+            value: "yes"
+          - name: DOMAIN
+            value: "example.com"
+          - name: HOSTNAMES
+            value: "mail.example.com,imap.example.com"
+          - name: MESSAGE_SIZE_LIMIT
+            value: "52428800"
+          - name: SUBNET
+            value: "10.42.0.0/16"
+          - name: RECIPIENT_DELIMITER
+            value: "+"
+          - name: LMTP_ADDRESS
+            value: RELEASE-NAME-mailu-dovecot:2525
+          - name: ANTISPAM_MILTER_ADDRESS
+            value: RELEASE-NAME-mailu-rspamd:11332
+          - name: ADMIN_ADDRESS
+            value: RELEASE-NAME-mailu-admin
+          - name: FRONT_ADDRESS
+            value: RELEASE-NAME-mailu-front
+          
+        ports:
+          - name: smtp
+            containerPort: 25
+            protocol: TCP
+          - name: smtp-ssl
+            containerPort: 465
+            protocol: TCP
+          - name: smtp-starttls
+            containerPort: 587
+            protocol: TCP
+          - name: smtp-auth
+            containerPort: 10025
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        startupProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'echo QUIT|nc localhost 25|grep "220 .* ESMTP Postfix"'
+          periodSeconds:  10 
+          failureThreshold: 30 
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'echo QUIT|nc localhost 25|grep "220 .* ESMTP Postfix"'
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'echo QUIT|nc localhost 25|grep "220 .* ESMTP Postfix"'
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-postfix
+  strategy:
+    type: Recreate
+---
+# Source: mailu/templates/redis.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/redis.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-redis
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:5-alpine
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: redis
+            mountPath: /data
+        ports:
+          - containerPort: 6379
+            name: redis
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        startupProbe:
+          exec:
+            command:
+              - /usr/local/bin/redis-cli
+              - info
+              - status
+          periodSeconds:  10 
+          failureThreshold: 30 
+          timeoutSeconds: 5
+        livenessProbe:
+          exec:
+            command:
+              - /usr/local/bin/redis-cli
+              - info
+              - status
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - /usr/local/bin/redis-cli
+              - info
+              - status
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-redis
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+# Source: mailu/templates/roundcube.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/webmail.yaml
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-roundcube
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: roundcube
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: roundcube
+    spec:
+      containers:
+      - name: roundcube
+        image: mailu/roundcube:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - mountPath: /data
+            name: data
+            subPath: roundcube
+        env:
+          - name: MESSAGE_SIZE_LIMIT
+            value: "52428800"
+          - name: IMAP_ADDRESS
+            value: RELEASE-NAME-mailu-dovecot
+          - name: FRONT_ADDRESS
+            value: RELEASE-NAME-mailu-front
+          - name: SECRET_KEY
+            value: "chang3m3!"
+          - name: SUBNET
+            value: 10.42.0.0/16
+          - name: ROUNDCUBE_DB_FLAVOR
+            value: sqlite
+        ports:
+          - name: http
+            containerPort: 80
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        startupProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 30 
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-roundcube
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+---
+# Source: mailu/templates/rspamd.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/security.yaml
+# (file is split into rspamd.yaml and clamav.yaml)
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: RELEASE-NAME-mailu-rspamd
+spec:
+  selector:
+    matchLabels:
+      app: RELEASE-NAME-mailu
+      component: rspamd
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: RELEASE-NAME-mailu
+        component: rspamd
+    spec:
+      hostname: rspamd # https://github.com/Mailu/helm-charts/issues/95
+      containers:
+      - name: rspamd
+        image: mailu/rspamd:1.8
+        imagePullPolicy: Always
+        volumeMounts:
+          - name: data
+            subPath: rspamd
+            mountPath: /var/lib/rspamd
+          - name: data
+            subPath: dkim
+            mountPath: /dkim
+        env:
+          - name: LOG_LEVEL
+            value: WARNING
+          - name: FRONT_ADDRESS
+            value: RELEASE-NAME-mailu-front
+          - name: REDIS_ADDRESS
+            value: RELEASE-NAME-mailu-redis
+          - name: ANTIVIRUS
+            value: clamav
+          - name: ANTIVIRUS_ADDRESS
+            value: RELEASE-NAME-mailu-clamav:3310
+          - name: SUBNET
+            value: "10.42.0.0/16"
+        ports:
+          - name: rspamd
+            containerPort: 11332
+            protocol: TCP
+          - name: rspamd-http
+            containerPort: 11334
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        startupProbe:
+          httpGet:
+            path: /
+            port: rspamd-http
+          periodSeconds:  10 
+          failureThreshold: 90 
+          timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /
+            port: rspamd-http
+          periodSeconds:  10 
+          failureThreshold: 3 
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: rspamd-http
+          periodSeconds:  10 
+          failureThreshold: 1 
+          timeoutSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: RELEASE-NAME-mailu-rspamd
+---
+# Source: mailu/templates/ingress.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/admin-ingress.yaml
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: RELEASE-NAME-mailu-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  labels:
+    app: RELEASE-NAME-mailu
+    component: admin
+spec:
+  tls:
+  - secretName: RELEASE-NAME-mailu-certificates
+    hosts:
+    - "mail.example.com"
+    - "imap.example.com"
+  rules:
+  - host: "mail.example.com"
+    http:
+      paths:
+      - path: "/"
+        backend:
+          service:
+            name: RELEASE-NAME-mailu-front
+            port: 
+              number: 80
+        pathType: ImplementationSpecific
+  - host: "imap.example.com"
+    http:
+      paths:
+      - path: "/"
+        backend:
+          service:
+            name: RELEASE-NAME-mailu-front
+            port: 
+              number: 80
+        pathType: ImplementationSpecific
+---
+# Source: mailu/templates/fetchmail.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/fetchmail.yaml
+---
+# Source: mailu/templates/single-pvc.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/pvc.yaml
+---
+# Source: mailu/templates/webdav.yaml
+# This file is derived from https://github.com/Mailu/Mailu/blob/master/docs/kubernetes/mailu/webdav.yaml
+---
+# Source: mailu/templates/certificate.yaml
+# This is the definition of the required ssl certificate for the mail system
+# It will be issued by cert-manager
+
+
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: RELEASE-NAME-mailu-certificates
+spec:
+  secretName: RELEASE-NAME-mailu-certificates
+  # re-new certificate when it expires in less than 60 days
+  renewBefore: 1440h0m0s
+  commonName: "mail.example.com"
+  dnsNames:
+  - "mail.example.com"
+  - "imap.example.com"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -75,6 +75,9 @@ external_relay: {}
 #    password: SECRET
 
 persistence:
+  # Setings for a single volume for all apps
+  # set single_pvc: false to use a per app volume and set the properties in <app>.persistence (ex. admin.persistence)
+  single_pvc: true
   size: 100Gi
   accessMode: ReadWriteOnce
   #annotations:
@@ -168,6 +171,14 @@ admin:
     repository: mailu/admin
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
+
   resources:
     requests:
       memory: 500Mi
@@ -194,6 +205,13 @@ redis:
   image:
     repository: redis
     tag: 5-alpine
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 200Mi
@@ -220,6 +238,13 @@ postfix:
     repository: mailu/postfix
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 2Gi
@@ -247,6 +272,13 @@ dovecot:
     repository: mailu/dovecot
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 500Mi
@@ -276,6 +308,16 @@ dovecot:
   #     mmap_disable = yes
   #     mail_max_userip_connections=100
 
+# rspamd and clamav must share their volume
+# use affinity to schedule both pods on the same node so RWO volumes keep working
+rspamd_clamav_persistence:
+  size: 20Gi
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  claimNameOverride: ""
+  #annotations:
+  #  "helm.sh/resource-policy": keep
+
 rspamd:
   # logLevel: WARNING
   image:
@@ -301,6 +343,16 @@ rspamd:
     periodSeconds: 10
     failureThreshold: 1
     timeoutSeconds: 5
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: component
+                operator: In
+                values:
+                  - clamav
+          topologyKey: kubernetes.io/hostname
 
 clamav:
   enabled: true
@@ -328,6 +380,16 @@ clamav:
     periodSeconds: 10
     failureThreshold: 1
     timeoutSeconds: 5
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: component
+                operator: In
+                values:
+                  - rspamd
+          topologyKey: kubernetes.io/hostname
 
 roundcube:
   enabled: true
@@ -336,6 +398,13 @@ roundcube:
     repository: mailu/roundcube
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 100Mi
@@ -364,6 +433,13 @@ webdav:
     repository: mailu/radicale
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   startupProbe:
     periodSeconds: 10
     failureThreshold: 30
@@ -381,6 +457,13 @@ mysql:
   image:
     repository: library/mariadb
     tag: 10.4.10
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 256Mi
@@ -408,6 +491,13 @@ fetchmail:
     repository: mailu/fetchmail
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 20Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 100Mi


### PR DESCRIPTION
Closes #39

Somewhat of a duplicate or followup of #90, I already started my solution and stumbled on the PR afterwards. Sorry @briantopping I did not wan to steal your thunder :)

I did however scroll through those comments and kept this PR aligned with the views there.

Some design choices:
* I set `$claimName` as template variable to keep things DRY (prepended with dollar to make clear that it is a template var)
* I decided to only add `rspamdClamavClaimName` to the helpers since that one is shared over templates (both deployments + pvc)
* It is backwards compatible due the `persistance.single_pvc: true` switch (although the affinity will be updated for clamav and rspamd)
* I added the affinity for clamav and rspamd as a default, even when `single_pvc: false`. I couldn't think of another transparent solution, with an if in the template you will want to merge with user set affinity etc, it becomes complicated really fast (I think).

Let me know what you guys think! I am open for other solutions!

I deployed and it works on my Ceph RWO volumes where as the current master does not without scheduling everything on the same node.