### PR TITLE
ingress: allow defining ingressClassName

### DIFF
--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     app: {{ $fullname }}
     component: admin
 spec:
+{{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
   tls:
   - secretName: {{ $fullname }}-certificates
     hosts:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -108,6 +108,7 @@ certmanager:
 ingress:
   externalIngress: true
   tlsFlavor: cert
+  className: ""
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
 


### PR DESCRIPTION
Ingress controllers are starting to ignore annotations as a means to define the class name. For example, `ingress-nginx` now ignores annotations by default.

This simple PR allows to specify `ingressClassName` from the values file.