### PR TITLE
postfix,dovecot: allow defining container.securityContext

### DIFF
--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -34,6 +34,10 @@ spec:
       - name: admin
         image: {{ .Values.dovecot.image.repository }}:{{ default .Values.mailuVersion .Values.dovecot.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.dovecot.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: data
             subPath: dovecotdata

--- a/mailu/templates/postfix.yaml
+++ b/mailu/templates/postfix.yaml
@@ -32,6 +32,10 @@ spec:
       - name: postfix
         image: {{ .Values.postfix.image.repository }}:{{ default .Values.mailuVersion .Values.postfix.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.postfix.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /queue
             name: data

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -224,6 +224,11 @@ postfix:
     repository: mailu/postfix
     # tag defaults to mailuVersion
     # tag: master
+  containerSecurityContext: {}
+  #    CRI-O users will need to add the following:
+  #    capabilities:
+  #      add:
+  #        - SYS_CHROOT
   resources:
     requests:
       memory: 2Gi
@@ -251,6 +256,11 @@ dovecot:
     repository: mailu/dovecot
     # tag defaults to mailuVersion
     # tag: master
+  containerSecurityContext: {}
+#    CRI-O users will need to add the following:
+#    capabilities:
+#      add:
+#        - SYS_CHROOT
   resources:
     requests:
       memory: 500Mi


### PR DESCRIPTION
Some runtimes, such as CRI-O, require granting additional capabilities to the container in order for `chroot` syscalls to success. This PR allows specifying the securityContext for the postfix and dovecot containers, which rely on these syscalls to work properly.