### PR TITLE
add secret key ref for SECRET_KEY env var

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -101,6 +101,8 @@ Check that the deployed pods are all running.
 | `postmaster`                      | Local part of the postmaster address | `postmaster`                              |
 | `passwordScheme`                  | Scheme used to hash passwords        | `PBKDF2`                                  |
 | `secretKey`                       | Session encryption key for admin and webmail | not set                           |
+| `secretKeyRef.name`               | Name of the Secret to fetch the secret key from | not set                        |
+| `secretKeyRef.key`                | The name of the key storing the secret key   | not set                           |
 | `subnet`                          | Subnet of PODs, used to configure from which IPs internal requests are allowed | `10.42.0.0/16` |
 | `mail.messageSizeLimitInMegabytes`| Message size limit in Megabytes      | `50`                                      |
 | `mail.authRatelimit`              | Rate limit for authentication requests | `10/minute;1000/hour`                   |

--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -102,8 +102,16 @@ spec:
             value: {{ .Values.subnet }}
           - name: PASSWORD_SCHEME
             value: "{{ default "PBKDF2" .Values.passwordScheme }}"
+          {{ if hasKey .Values "secretKeyRef" }}
           - name: SECRET_KEY
-            value: "{{ required "secretKey" .Values.secretKey }}"
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secretKeyRef.name }}
+                key: {{ .Values.secretKeyRef.key}}
+          {{ else }}
+           - name: SECRET_KEY
+             value: "{{ required "secretKey" .Values.secretKey }}"
+          {{- end}}
           - name: AUTH_RATELIMIT
             value: "{{ required "mail.authRatelimit" .Values.mail.authRatelimit }}"
           {{- if .Values.initialAccount }}

--- a/mailu/templates/dovecot.yaml
+++ b/mailu/templates/dovecot.yaml
@@ -85,8 +85,16 @@ spec:
             value: {{ include "mailu.fullname" . }}-redis
           - name: WEBMAIL
             value: none
+          {{ if hasKey .Values "secretKeyRef" }}
+          - name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secretKeyRef.name }}
+                key: {{ .Values.secretKeyRef.key}}
+          {{ else }}
           - name: SECRET_KEY
             value: "{{ required "secretKey" .Values.secretKey }}"
+          {{- end}}
         ports:
           - name: auth
             containerPort: 2102

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -57,8 +57,16 @@ spec:
             value: {{ include "mailu.fullname" . }}-dovecot
           - name: FRONT_ADDRESS
             value: {{ include "mailu.fullname" . }}-front
+          {{ if hasKey .Values "secretKeyRef" }}
           - name: SECRET_KEY
-            value: "{{ required "secretKey" .Values.secretKey }}"
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secretKeyRef.name }}
+                key: {{ .Values.secretKeyRef.key}}
+          {{ else }}
+           - name: SECRET_KEY
+             value: "{{ required "secretKey" .Values.secretKey }}"
+          {{- end}}
           - name: SUBNET
             value: {{ .Values.subnet }}
           - name: ADMIN


### PR DESCRIPTION
This allow setting a secret key ref instead of directly passing in a
secret in.

for example with the secret

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: mailu-secret
data:
  my-key: YmFyCg==
```

it could be used from this chart like

```yaml
domain: mail.mydomain.com
hostnames:
- mail.mydomain.com
initialAccount:
  domain: mail.mydomain.com
  password: chang3m3!
  username: mailadmin
logLevel: INFO
mail:
  authRatelimit: 100/minute;3600/hour
  messageSizeLimitInMegabytes: 200
persistence:
  size: 100Gi
  storageClass: fast
secretKeyRef:
  name: mailu-secret
  key: my-key
```