### PR TITLE
Expose the sieve port for mail filtering

### DIFF
--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -165,6 +165,12 @@ spec:
             {{- if .Values.front.hostPort.enabled }}
             hostPort: 587
             {{- end}}
+          - name: sieve
+            protocol: TCP
+            containerPort: 4190
+            {{- if .Values.front.hostPort.enabled }}
+            hostPort: 4190
+            {{- end}}
           - name: auth
             containerPort: 8000
             protocol: TCP
@@ -266,6 +272,9 @@ spec:
   - name: imap-auth
     port: 10143
     protocol: TCP
+  - name: sieve
+    port: 4190
+    protocol: TCP
   - name: http
     port: 80
     protocol: TCP
@@ -340,6 +349,14 @@ spec:
   {{- if .submission }}
   - name: smtpd
     port: 587
+    protocol: TCP
+  {{- end }}
+{{- end }}
+
+{{- with .sieve }}
+  {{- if .sieve }}
+  - name: sieve
+    port: 4190
     protocol: TCP
   {{- end }}
 {{- end }}

--- a/mailu/test.yml
+++ b/mailu/test.yml
@@ -186,6 +186,9 @@ spec:
   - name: imap-auth
     port: 10143
     protocol: TCP
+  - name: sieve
+    port: 4190
+    protocol: TCP
   - name: http
     port: 80
     protocol: TCP
@@ -668,6 +671,9 @@ spec:
             hostPort: 587
           - name: auth
             containerPort: 8000
+            protocol: TCP
+          - name: sieve
+            containerPort: 4190
             protocol: TCP
           - name: http
             containerPort: 80

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -178,6 +178,8 @@ front:
       smtp: true
       smtps: true
       submission: true
+    sieve:
+      sieve: false
 
 admin:
   # logLevel: WARNING


### PR DESCRIPTION
I use sieve a lot for my filtering. In order to use Mailu I need the sieve port exposed.

Let me know if there's anything else I need to do.