### PR TITLE
Fix #159 - Incorrect version of Cert-Manager

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -92,7 +92,7 @@ Check that the deployed pods are all running.
 ## Configuration
 | Parameter                         | Description                          | Default                                   |
 | --------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `mailuVersion`                    | Version/tag of mailu images - must be master or a version >=1.9 | `master`                                  |
+| `mailuVersion`                    | Version/tag of mailu images - must be master or a version >=1.9 | `master`       |
 | `logLevel`                        | Level of logging                     | `WARNING`                                 |
 | `nameOverride`                    | Override the resource name prefix    | `mailu`                                   |
 | `clusterDomain`                   | Change the cluster DNS root          | `cluster.local`                           |
@@ -112,20 +112,20 @@ Check that the deployed pods are all running.
 | `certmanager.enabled`             | Enable the use of CertManager to generate secrets         | `ClusterIssuer`      |
 | `certmanager.issuerType`          | Issuer type for cert manager         | `ClusterIssuer`                           |
 | `certmanager.issuerName`          | Name of a preconfigured cert issuer  | `letsencrypt`                             |
-| `certmanager.apiVersion`          | API-Version for certmanager CRDs     | `cert-manager.io/v1alpha2`                |
+| `certmanager.apiVersion`          | API-Version for certmanager CRDs     | `cert-manager.io/v1`                      |
 | `persistence.size`                | requested PVC size                   | `100Gi`                                   |
 | `persistence.storageClass`        | storageClass to use for persistence  | not set                                   |
 | `persistence.accessMode`          | accessMode to use for persistence    | `ReadWriteOnce`                           |
-| `persistence.annotations`          | Annotations to use in the PVC.    | `{}`                           |
+| `persistence.annotations`         | Annotations to use in the PVC.       | `{}`                                      |
 | `persistence.hostPath`            | path of the hostPath persistence     | not set                                   |
 | `persistence.existingClaim`       | existing PVC                         | not set                                   |
 | `persistence.claimNameOverride`   | override the generated claim name    | not set                                   |
 | `webdav.enabled`                  | enable webdav server                 | `false`                                   |
 | `ingress.externalIngress`         | Use externally provided nginx        | `true`                                    |
 | `ingress.tlsFlavor`               | Do not change unless you have a custom way of generating the certificates. [Allowed options](https://mailu.io/1.7/compose/setup.html#tls-certificates)  | `cert` (uses certificates provided by cert-manager)                                   |
-| `ingress.annotations`               | Annotations for the ingress resource, if enabled. Useful e.g. for configuring the NGINX controller configuration.  | `nginx.ingress.kubernetes.io/proxy-body-size: "0"`                                   |
+| `ingress.annotations`             | Annotations for the ingress resource, if enabled. Useful e.g. for configuring the NGINX controller configuration.  | `nginx.ingress.kubernetes.io/proxy-body-size: "0"`                                   |
 | `ingress.realIpHeader`            | Header from http(s) ingress that contains the real client IP | `X-Forwarded-For` |
-| `ingress.realIpFrom`              | IP/Network from where `realIpHeader` is accepted | `0.0.0.0/0` |
+| `ingress.realIpFrom`              | IP/Network from where `realIpHeader` is accepted | `0.0.0.0/0`                   |
 | `roundcube.enabled`               | enable roundcube webmail             | `true`                                    |
 | `clamav.enabled`                  | enable clamav antivirus              | `true`                                    |
 | `dovecot.overrides`               | enable dovecot overrides             | not set                                   |
@@ -134,7 +134,7 @@ Check that the deployed pods are all running.
 | `database.type`                   | type of database used for mailu      | `sqlite`                                  |
 | `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
 | `database.mysql.*`                | mysql specific settings, see below   | not set                                   |
-| `timezone`                        | time zone for PODs, see below        | not set                                 |
+| `timezone`                        | time zone for PODs, see below        | not set                                   |
 
 ### Example values.yaml to get started
 

--- a/mailu/test.yml
+++ b/mailu/test.yml
@@ -1113,7 +1113,7 @@ spec:
 # It will be issued by cert-manager
 
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: RELEASE-NAME-mailu-certificates

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -112,7 +112,7 @@ certmanager:
   enabled: true
   issuerType: ClusterIssuer
   issuerName: letsencrypt
-  apiVersion: cert-manager.io/v1alpha2
+  apiVersion: cert-manager.io/v1
 
 # Set ingress and loadbalancer config
 ingress:


### PR DESCRIPTION
Replace all instances of `cert-manager.io/v1alpha2` with `cert-manager.io/v1` (fixes #159)