### PR TITLE
Support new RATELIMIT features

### DIFF
--- a/mailu/templates/admin.yaml
+++ b/mailu/templates/admin.yaml
@@ -104,8 +104,18 @@ spec:
             value: "{{ default "PBKDF2" .Values.passwordScheme }}"
           - name: SECRET_KEY
             value: "{{ required "secretKey" .Values.secretKey }}"
-          - name: AUTH_RATELIMIT
-            value: "{{ required "mail.authRatelimit" .Values.mail.authRatelimit }}"
+          - name: AUTH_RATELIMIT_IP
+            value: "{{ required "mail.authRatelimitIP" .Values.mail.authRatelimitIP }}"
+          - name: AUTH_RATELIMIT_IP_V4_MASK
+            value: "{{ required "mail.authRatelimitIPv4Mask" .Values.mail.authRatelimitIPv4Mask }}"
+          - name: AUTH_RATELIMIT_IP_V6_MASK
+            value: "{{ required "mail.authRatelimitIPv6Mask" .Values.mail.authRatelimitIPv6Mask }}"
+          - name: AUTH_RATELIMIT_USER
+            value: "{{ required "mail.authRatelimitUser" .Values.mail.authRatelimitUser }}"
+          - name: AUTH_RATELIMIT_EXEMPTION_LENGTH
+            value: "{{ required "mail.authRatelimitExemtionLength" .Values.mail.authRatelimitExemtionLength }}"
+          - name: AUTH_RATELIMIT_EXEMPTION
+            value: "{{ default "" .Values.mail.authRatelimitExemtion }}"
           {{- if .Values.initialAccount }}
           - name: INITIAL_ADMIN_ACCOUNT
             value: {{ required "initialAccount.username" .Values.initialAccount.username }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -105,7 +105,14 @@ postmaster: postmaster
 
 mail:
   messageSizeLimitInMegabytes: 50
-  authRatelimit: 10/minute;1000/hour
+
+  # Configuration to prevent brute-force attacks. See the documentation for further information: https://mailu.io/master/configuration.html
+  authRatelimitIP: 60/hour
+  authRatelimitIPv4Mask: 24
+  authRatelimitIPv6Mask: 56
+  authRatelimitUser: 100/day
+  authRatelimitExemtionLength: 86400
+  # authRatelimitExemtion:
 
 # certmanager settings
 certmanager:


### PR DESCRIPTION
This PR adds support for new RATELIMIT features introduced in 1.9.

I'm pretty new to developing helm charts, so I don't know if this is the best way to do it.
Feel free to criticize :-D

> The new chart should fail if any of the old settings are in use.

This is not done:
1. I don't know how to make the chart fail if a value is set.
2. I don't think it's is better to keep thinks simple and instead document the "changed" behavior.

close #149