### PR TITLE
Add option for seperate PVCs for rspamd/clamav

### DIFF
--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -3,6 +3,9 @@
 
 {{- if .Values.clamav.enabled }}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.rspamd.persistence.claimNameOverride | default (printf "%s-clamav" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -89,7 +92,11 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
+            {{- if not .Values.rspamd_clamav_persistence.single_pvc }}
+            claimName: {{ $claimName }}
+            {{- else }}
             claimName: {{ include "mailu.rspamdClamavClaimName" . }}
+            {{- end }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
@@ -101,6 +108,28 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+
+{{- if and (not .Values.persistence.single_pvc) (not .Values.rspamd_clamav_persistence.single_pvc) }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.clamav.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.clamav.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.clamav.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.clamav.persistence.size }}
+  {{- if .Values.clamav.persistence.storageClass }}
+  storageClassName: {{ .Values.clamav.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/templates/rspamd-clamav-pvc.yml
+++ b/mailu/templates/rspamd-clamav-pvc.yml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.single_pvc }}
+{{- if and (not .Values.persistence.single_pvc) (.Values.rspamd_clamav_persistence.single_pvc) }}
 ---
 
 apiVersion: v1

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -3,6 +3,9 @@
 
 {{- $clusterDomain := default "cluster.local" .Values.clusterDomain}}
 
+{{- /* Define persistantVolume claimName */}}
+{{- $claimName := .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.rspamd.persistence.claimNameOverride | default (printf "%s-rspamd" (include "mailu.fullname" .)) }}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -115,13 +118,39 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
+            {{- if not .Values.rspamd_clamav_persistence.single_pvc }}
+            claimName: {{ $claimName }}
+            {{- else }}
             claimName: {{ include "mailu.rspamdClamavClaimName" . }}
+            {{- end }}
         {{- if .Values.timezone }}
         - name: zoneinfo
           hostPath:
             path: /usr/share/zoneinfo
             type: Directory
         {{- end }}
+
+{{- if and (not .Values.persistence.single_pvc) (not .Values.rspamd_clamav_persistence.single_pvc) }}
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name:  {{ $claimName }}
+{{- if .Values.rspamd.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.rspamd.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+    - {{ .Values.rspamd.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.rspamd.persistence.size }}
+  {{- if .Values.rspamd.persistence.storageClass }}
+  storageClassName: {{ .Values.rspamd.persistence.storageClass }}
+  {{- end }}
+{{- end }}
 
 ---
 

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -332,13 +332,22 @@ dovecot:
   #     mmap_disable = yes
   #     mail_max_userip_connections=100
 
-# rspamd and clamav must share their volume
-# use affinity to schedule both pods on the same node so RWO volumes keep working
+# historically rspamd and clamav shared their volumes in this chart
+# this isn't needed anymore. to maintain backward compatibility and give users
+# some time to migrate we keep this here.
+#
+# if you want a "shared" volume keep in mind you have to use affinity rules on
+# rspamd and clamav pods so that both pods are scheduled on the same node
+# to keep RWO volumes working
+#
+# otherwise set rspamd_clamav_persistence.single_pvc to true and review
+# rspamd.persistence and clamav.persistence
 rspamd_clamav_persistence:
   size: 20Gi
   storageClass: ""
   accessMode: ReadWriteOnce
   claimNameOverride: ""
+  single_pvc: false
   #annotations:
   #  "helm.sh/resource-policy": keep
 
@@ -348,6 +357,13 @@ rspamd:
     repository: mailu/rspamd
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 1Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 100Mi
@@ -375,6 +391,13 @@ clamav:
     repository: mailu/clamav
     # tag defaults to mailuVersion
     # tag: master
+  persistence:
+    size: 2Gi
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    claimNameOverride: ""
+    #annotations:
+    #  "helm.sh/resource-policy": keep
   resources:
     requests:
       memory: 1Gi


### PR DESCRIPTION
Hi,

according to https://github.com/Mailu/helm-charts/blob/master/mailu/values.yaml#L335 rspamd and clamav needs a shared volume.
However this isn't the case and also the volume is already split into "subvolumes" by using subPaths. So clamav can't access rspamd data and vice versa.

Also I don't see any other technical reason for this since all communication between rspamd and clamav is done over network since at least 2018. AFAIK the clamav integration within rspamd never used the disk to share mail data for scanning.

This PR adds an option **rspamd_clamav_persistence.single_pvc** which is set to **false** by default. This keeps everything like it's now (i.e. keeps the shared volume).
Setting this value to **true** will create two PVC **mailu-clamav** and **mailu-rspamd**. With seperate PVCs users don't need to apply any affinity rules on rspamd and clamav to keep RWO working.

I've also lowered the requested size for both. **mailu-clamav** will take about 2G and **mailu-rspamd** 1G. ClamAV only stores it's clamav database in the PVC which is currently about 240 MB.
RSPAMD only takes about ~30 MB after a fresh install. One install (not mailu) which already runs about 3 years now currently only takes about 50 MB. So these values should be save IMHO.

Maybe in a later version (and more testing) the default value for **rspamd_clamav_persistence.single_pvc** could be changed to true.