### PR TITLE
Bump version to latest mailu-1.9.26

### DIFF
--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -95,7 +95,7 @@ persistence:
 subnet: 10.42.0.0/16
 
 # Version of mailu docker images to use when not specified otherwise
-mailuVersion: 1.9.10
+mailuVersion: 1.9.26
 
 # default log level. can be overridden globally or per service
 logLevel: WARNING


### PR DESCRIPTION
Current version is still 1.9.10 which causes issues with current coredns implementations. Mailu-admin 1.9.20 introtuced a patch to fix this.
See issue #144 

This bumps the version to the latest available mailu version 1.9.26 since later versions also include security fixes (openssl and zlib).