### PR TITLE
Add support for containerSecurityContext

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.9"
 description: Mailu mail system
 name: mailu
-version: 0.3.1
+version: 0.3.3
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -137,6 +137,7 @@ Check that the deployed pods are all running.
 | `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
 | `database.mysql.*`                | mysql specific settings, see below   | not set                                   |
 | `timezone`                        | time zone for PODs, see below        | not set                                   |
+| `containerSecurityContext`        | enables SecurityContext              | `false`                                   |
 
 ### Example values.yaml to get started
 

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -137,7 +137,7 @@ Check that the deployed pods are all running.
 | `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
 | `database.mysql.*`                | mysql specific settings, see below   | not set                                   |
 | `timezone`                        | time zone for PODs, see below        | not set                                   |
-| `{app}.containerSecurityContext`  | enables SecurityContext for $app     | `false`                                   |
+| `{app}.containerSecurityContext`  | Uses the given SecurityContext for $app (e.g. postfix, dovecot, clamav, ...)     | not set                                   |
 
 ### Example values.yaml to get started
 

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -137,7 +137,7 @@ Check that the deployed pods are all running.
 | `database.roundcubeType`          | type of database used for roundcube  | `sqlite`                                  |
 | `database.mysql.*`                | mysql specific settings, see below   | not set                                   |
 | `timezone`                        | time zone for PODs, see below        | not set                                   |
-| `containerSecurityContext`        | enables SecurityContext              | `false`                                   |
+| `{app}.containerSecurityContext`  | enables SecurityContext for $app     | `false`                                   |
 
 ### Example values.yaml to get started
 

--- a/mailu/templates/clamav.yaml
+++ b/mailu/templates/clamav.yaml
@@ -38,6 +38,10 @@ spec:
       - name: clamav
         image: {{ .Values.clamav.image.repository }}:{{ default .Values.mailuVersion .Values.clamav.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.clamav.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: data
             subPath: clamav

--- a/mailu/templates/fetchmail.yaml
+++ b/mailu/templates/fetchmail.yaml
@@ -41,7 +41,11 @@ spec:
       - name: admin
         image: {{ .Values.fetchmail.image.repository }}:{{ default .Values.mailuVersion .Values.fetchmail.image.tag }}
         imagePullPolicy: Always
-        volumeMounts:
+        {{- with .Values.fetchmail.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
+        volumeMounts:      
           - name: data
             subPath: dovecotdata
             mountPath: /data

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -44,6 +44,10 @@ spec:
       - name: front
         image: {{ .Values.front.image.repository }}:{{ default .Values.mailuVersion .Values.front.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.front.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: certs
             mountPath: /certs

--- a/mailu/templates/redis.yaml
+++ b/mailu/templates/redis.yaml
@@ -35,6 +35,10 @@ spec:
       - name: redis
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.redis.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: data
             subPath: redis

--- a/mailu/templates/roundcube.yaml
+++ b/mailu/templates/roundcube.yaml
@@ -37,6 +37,10 @@ spec:
       - name: roundcube
         image: {{ .Values.roundcube.image.repository }}:{{ default .Values.mailuVersion .Values.roundcube.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.roundcube.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /data
             name: data

--- a/mailu/templates/rspamd.yaml
+++ b/mailu/templates/rspamd.yaml
@@ -39,6 +39,10 @@ spec:
       - name: rspamd
         image: {{ .Values.rspamd.image.repository }}:{{ default .Values.mailuVersion .Values.rspamd.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.rspamd.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: data
             subPath: rspamd

--- a/mailu/templates/webdav.yaml
+++ b/mailu/templates/webdav.yaml
@@ -37,6 +37,10 @@ spec:
       - name: webdav
         image: {{ .Values.webdav.image.repository }}:{{ default .Values.mailuVersion .Values.webdav.image.tag }}
         imagePullPolicy: Always
+        {{- with .Values.webdav.containerSecurityContext }}
+        securityContext:
+        {{- . | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /data
             name: data


### PR DESCRIPTION
The current setup is not usable in clusters that are using default scc: restricted. 
In this specific case, we need SYS_CHROOT in the Redis app which is not possible due to the default used SCC.
By adding security context to each application we are allowing users to define which SCC they want to use. 

The issue https://github.com/Mailu/helm-charts/issues/163 could be closed with this MR.