### PR TITLE
 Remove limits from yalues.yaml by default 

### DIFF
--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -224,11 +224,6 @@ redis:
     requests:
       memory: 200Mi
       cpu: 100m
-    
-    
-    :
-      memory: 300Mi
-      cpu: 200m
   startupProbe:
     periodSeconds: 10
     failureThreshold: 30

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -135,9 +135,6 @@ front:
     requests:
       memory: 100Mi
       cpu: 100m
-    limits:
-      memory: 200Mi
-      cpu: 200m
   startupProbe:
     periodSeconds: 10
     failureThreshold: 30
@@ -197,9 +194,6 @@ admin:
     requests:
       memory: 500Mi
       cpu: 500m
-    limits:
-      memory: 500Mi
-      cpu: 500m
   podAnnotations: {}
   startupProbe:
     periodSeconds: 10
@@ -230,7 +224,9 @@ redis:
     requests:
       memory: 200Mi
       cpu: 100m
-    limits:
+    
+    
+    :
       memory: 300Mi
       cpu: 200m
   startupProbe:
@@ -268,9 +264,6 @@ postfix:
     requests:
       memory: 2Gi
       cpu: 500m
-    limits:
-      memory: 2Gi
-      cpu: 500m
   startupProbe:
     periodSeconds: 10
     failureThreshold: 30
@@ -305,9 +298,6 @@ dovecot:
     #  "helm.sh/resource-policy": keep
   resources:
     requests:
-      memory: 500Mi
-      cpu: 500m
-    limits:
       memory: 500Mi
       cpu: 500m
   startupProbe:
@@ -368,9 +358,6 @@ rspamd:
     requests:
       memory: 100Mi
       cpu: 100m
-    limits:
-      memory: 200Mi
-      cpu: 200m
   startupProbe: # give it 15 minutes for initial rule compilation
     periodSeconds: 10
     failureThreshold: 90
@@ -401,9 +388,6 @@ clamav:
   resources:
     requests:
       memory: 1Gi
-      cpu: 1000m
-    limits:
-      memory: 2Gi
       cpu: 1000m
   startupProbe: # give it 10 minutes for initial freshclam update
     periodSeconds: 10
@@ -449,9 +433,6 @@ roundcube:
     requests:
       memory: 100Mi
       cpu: 100m
-    limits:
-      memory: 200Mi
-      cpu: 200m
   startupProbe:
     periodSeconds: 10
     failureThreshold: 30
@@ -508,9 +489,6 @@ mysql:
     requests:
       memory: 256Mi
       cpu: 100m
-    limits:
-      memory: 512Mi
-      cpu: 200m
   startupProbe:
     periodSeconds: 10
     failureThreshold: 30
@@ -542,7 +520,4 @@ fetchmail:
     requests:
       memory: 100Mi
       cpu: 100m
-    limits:
-      memory: 200Mi
-      cpu: 200m
   delay: 600


### PR DESCRIPTION
limits should be set explicitly by the user, as default limits can have bad default behavior.

I couldn't deploy this chart AS-IS as `rspamd` got in a crashloop because it went OOM constantly.
Usually helm charts don't contain default limits but allow users to set them if needed. this way we avoid artificially limiting the chart by default and still give users the flexibility 