### PR TITLE
Allow labels overriding for ingress.yaml template

### DIFF
--- a/mailu/templates/ingress.yaml
+++ b/mailu/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     app: {{ $fullname }}
     component: admin
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
 {{- with .Values.ingress.className }}
   ingressClassName: {{ . }}


### PR DESCRIPTION
When allowing labels for ingress.yaml template we can easily use kcert to handle SSL cert management, cf.: https://github.com/nabsul/kcert. Works fine for me with no other overhead ;)