### PR TITLE
add client autoconfig configmap

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.9"
 description: Mailu mail system
 name: mailu
-version: 0.3.3
+version: 0.3.4
 icon: https://mailu.io/master/_images/logo.png

--- a/mailu/templates/certificate.yaml
+++ b/mailu/templates/certificate.yaml
@@ -2,6 +2,11 @@
 # It will be issued by cert-manager
 {{ if .Values.certmanager.enabled }}
 
+{{- $dnshostnames := .Values.hostnames -}}
+{{- if .Values.front.autoConfigUrl -}}
+{{- $dnshostnames = append $dnshostnames .Values.front.autoConfigUrl | uniq -}}
+{{- end -}}
+
 apiVersion: {{ .Values.certmanager.apiVersion }}
 kind: Certificate
 metadata:
@@ -12,7 +17,7 @@ spec:
   renewBefore: 1440h0m0s
   commonName: "{{ first (required "hostnames" .Values.hostnames) }}"
   dnsNames:
-{{- range .Values.hostnames }}
+{{- range $dnshostnames }}
   - "{{ . }}"
 {{- end }}
   issuerRef:

--- a/mailu/templates/configmap.yaml
+++ b/mailu/templates/configmap.yaml
@@ -1,0 +1,45 @@
+## Creates config map for front nginx, it provides the XML used for the clients config
+{{- if .Values.front.autoConfigUrl  -}}
+{{- $main_hostname := first .Values.hostnames -}}
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ include "mailu.fullname" . }}-front-override
+data:
+  autoconfiguration.conf: 
+    location ^~ /mail/config-v1.1.xml {
+    return 200 "<?xml version=\"1.0\"?>
+    <clientConfig version=\"1.1\">
+    <emailProvider id=\"%EMAILDOMAIN%\">
+    <domain>%EMAILDOMAIN%</domain>
+
+    <displayName>Email</displayName>
+    <displayShortName>Email</displayShortName>
+
+    <incomingServer type=\"imap\">
+    <hostname>{{- $main_hostname -}}</hostname>
+    <port>993</port>
+    <socketType>SSL</socketType>
+    <username>%EMAILADDRESS%</username>
+    <authentication>password-cleartext</authentication>
+    </incomingServer>
+
+    <outgoingServer type=\"smtp\">
+    <hostname>{{- $main_hostname -}}</hostname>
+    <port>465</port>
+    <socketType>SSL</socketType>
+    <username>%EMAILADDRESS%</username>
+    <authentication>password-cleartext</authentication>
+    <addThisServer>true</addThisServer>
+    <useGlobalPreferredServer>true</useGlobalPreferredServer>
+    </outgoingServer>
+
+    <documentation url=\"https://{{- $main_hostname -}}/admin/ui/client\">
+    <descr lang=\"en\">Configure your email client</descr>
+    </documentation>
+    </emailProvider>
+    </clientConfig>\r\n";
+    }
+    
+{{ end -}}

--- a/mailu/templates/front.yaml
+++ b/mailu/templates/front.yaml
@@ -60,6 +60,10 @@ spec:
             mountPath: /etc/localtime
             readOnly: true
           {{- end }}
+          {{- if .Values.front.autoConfigUrl}}
+          - name: {{ include "mailu.fullname" . }}-front-override
+            mountPath: /overrides
+          {{- end }}
         env:
           - name: LOG_LEVEL
             value: {{ default .Values.logLevel .Values.front.logLevel }}
@@ -212,6 +216,11 @@ spec:
           timeoutSeconds: {{ default 5 .Values.front.readinessProbe.timeoutSeconds }}
         {{- end }}
       volumes:
+        {{- if .Values.front.autoConfigUrl}}
+        - configMap:
+          defaultMode: 440
+          name: {{ include "mailu.fullname" . }}-front-override
+        {{- end }}
         - name: certs
           secret:
             items:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -3,6 +3,7 @@
 # A list of mail hostnames is required. The first will be used as primary mail hostname
 #hostnames:
 #  - mail.example.com
+#  - autoconfig.example.com
 #  - imap.example.com
 
 # The mail domain is required. See https://github.com/Mailu/Mailu/blob/master/docs/faq.rst#what-is-the-difference-between-domain-and-hostnames
@@ -129,7 +130,7 @@ certmanager:
 ingress:
   externalIngress: true
   tlsFlavor: cert
-  className: ""
+  className: "traefik"
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
   realIpHeader: X-Forwarded-For
@@ -165,6 +166,8 @@ front:
   controller:
     kind: Deployment
   nodeSelector: {}
+  ## serve xml for client autoconfiguration: https://mailu.io/1.9/faq.html#how-do-i-setup-client-autoconfiguration
+  # autoConfigUrl: "autoconfig.example.com"
 
   # Expose front mail ports via hostPort
   hostPort:


### PR DESCRIPTION
This pullrequest will add a configmap that automatically configs nginx to allow serving the xml file for clients autoconfiguration:
this automates the following instructions
https://mailu.io/1.9/faq.html#how-do-i-setup-client-autoconfiguration

as a side effect or bonus, since this config map maps into the overrides folder this will allow an user to add more files as needed without changing the deployment