### PR TITLE
fix: Helm error when deploying with webdav.enabled=true because of missing template #232

### DIFF
--- a/mailu/templates/_claims.tpl
+++ b/mailu/templates/_claims.tpl
@@ -27,3 +27,8 @@
 {{ define "mailu.fetchmail.claimName" }}
 {{- .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.fetchmail.persistence.claimNameOverride | default (printf "%s-fetchmail" (include "mailu.fullname" .)) -}}
 {{- end -}}
+
+{{/* Webdav pod persistent volume claim name */}}
+{{ define "mailu.webdav.claimName" }}
+{{- .Values.persistence.single_pvc | ternary (include "mailu.claimName" .) .Values.webdav.persistence.claimNameOverride | default (printf "%s-webdav" (include "mailu.fullname" .)) -}}
+{{- end -}}


### PR DESCRIPTION
Simply added the missing template in the same fashion as all other templates in `_claims.tpl`.

Closes #232