### PR TITLE
feat: add securityContext and podSecurityContext options

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -336,6 +336,11 @@ Check that the deployed pods are all running.
 | `front.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`            |
 | `front.initContainers`                        | Add additional init containers to the pod                                             | `[]`            |
 | `front.priorityClassName`                     | Pods' priorityClassName                                                               | `""`            |
+| `front.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`         |
+| `front.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`          |
+| `front.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`         |
+| `front.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`          |
+| `front.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`         |
 | `front.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`             |
 | `front.affinity`                              | Affinity for front pod assignment                                                     | `{}`            |
 | `front.tolerations`                           | Tolerations for pod assignment                                                        | `[]`            |
@@ -353,58 +358,63 @@ Check that the deployed pods are all running.
 
 ### Admin parameters
 
-| Name                                       | Description                                                                           | Value               |
-| ------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------- |
-| `admin.enabled`                            | Enable access to the admin interface                                                  | `true`              |
-| `admin.uri`                                | URI to access the admin interface                                                     | `/admin`            |
-| `admin.logLevel`                           | Override default log level                                                            | `""`                |
-| `admin.image.repository`                   | Pod image repository                                                                  | `mailu/admin`       |
-| `admin.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `admin.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `admin.persistence.size`                   | Pod pvc size                                                                          | `20Gi`              |
-| `admin.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `admin.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `admin.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `admin.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `admin.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `admin.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `admin.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `admin.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `admin.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `admin.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `admin.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `admin.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `admin.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `admin.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `admin.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `admin.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `admin.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `admin.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `admin.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`             |
-| `admin.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `admin.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `admin.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                 |
-| `admin.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                 |
-| `admin.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `admin.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `admin.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `admin.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `admin.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `admin.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `admin.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `admin.affinity`                           | Affinity for admin pod assignment                                                     | `{}`                |
-| `admin.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `admin.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `admin.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `admin.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `admin.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `admin.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `admin.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `admin.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `admin.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `admin.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `admin.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `admin.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| Name                                          | Description                                                                           | Value               |
+| --------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `admin.enabled`                               | Enable access to the admin interface                                                  | `true`              |
+| `admin.uri`                                   | URI to access the admin interface                                                     | `/admin`            |
+| `admin.logLevel`                              | Override default log level                                                            | `""`                |
+| `admin.image.repository`                      | Pod image repository                                                                  | `mailu/admin`       |
+| `admin.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `admin.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `admin.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
+| `admin.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `admin.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `admin.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                |
+| `admin.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `admin.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `admin.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `admin.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `admin.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `admin.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `admin.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `admin.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `admin.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                 |
+| `admin.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `admin.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `admin.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `admin.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                 |
+| `admin.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `admin.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `admin.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`             |
+| `admin.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `admin.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `admin.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `1`                 |
+| `admin.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `3`                 |
+| `admin.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `admin.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `admin.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `admin.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `admin.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `admin.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `admin.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `admin.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `admin.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `admin.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `admin.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `admin.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `admin.affinity`                              | Affinity for admin pod assignment                                                     | `{}`                |
+| `admin.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `admin.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
+| `admin.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `admin.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `admin.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `admin.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `admin.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `admin.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `admin.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `admin.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `admin.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `admin.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
 ### Redis parameters
 
@@ -426,441 +436,481 @@ Check that the deployed pods are all running.
 
 ### Postfix parameters
 
-| Name                                         | Description                                                                           | Value               |
-| -------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `postfix.logLevel`                           | Override default log level                                                            | `""`                |
-| `postfix.image.repository`                   | Pod image repository                                                                  | `mailu/postfix`     |
-| `postfix.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `postfix.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `postfix.persistence.size`                   | Pod pvc size                                                                          | `20Gi`              |
-| `postfix.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `postfix.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `postfix.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `postfix.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `postfix.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `postfix.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `postfix.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `postfix.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `postfix.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `postfix.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `postfix.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `postfix.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `postfix.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `postfix.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `postfix.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `postfix.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `postfix.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `postfix.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `postfix.startupProbe.enabled`               | Enable startupProbe                                                                   | `true`              |
-| `postfix.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `postfix.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `postfix.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                 |
-| `postfix.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `30`                |
-| `postfix.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `postfix.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `postfix.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `postfix.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `postfix.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `postfix.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `postfix.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `postfix.affinity`                           | Affinity for postfix pod assignment                                                   | `{}`                |
-| `postfix.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `postfix.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `postfix.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `postfix.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `postfix.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `postfix.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `postfix.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `postfix.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `postfix.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `postfix.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `postfix.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `postfix.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
-| `postfix.overrides`                          | Enable postfix overrides                                                              | `{}`                |
+| Name                                            | Description                                                                           | Value               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `postfix.logLevel`                              | Override default log level                                                            | `""`                |
+| `postfix.image.repository`                      | Pod image repository                                                                  | `mailu/postfix`     |
+| `postfix.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `postfix.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `postfix.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
+| `postfix.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `postfix.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `postfix.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                |
+| `postfix.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `postfix.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `postfix.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `postfix.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `postfix.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `postfix.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `postfix.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `postfix.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `postfix.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                 |
+| `postfix.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `postfix.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `postfix.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `postfix.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                 |
+| `postfix.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `postfix.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `postfix.startupProbe.enabled`                  | Enable startupProbe                                                                   | `true`              |
+| `postfix.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `postfix.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `postfix.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `1`                 |
+| `postfix.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `30`                |
+| `postfix.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `postfix.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `postfix.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `postfix.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `postfix.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `postfix.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `postfix.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `postfix.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `postfix.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `postfix.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `postfix.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `postfix.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `postfix.affinity`                              | Affinity for postfix pod assignment                                                   | `{}`                |
+| `postfix.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `postfix.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
+| `postfix.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `postfix.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `postfix.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `postfix.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `postfix.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `postfix.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `postfix.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `postfix.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `postfix.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `postfix.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| `postfix.overrides`                             | Enable postfix overrides                                                              | `{}`                |
 
 ### Dovecot parameters
 
-| Name                                         | Description                                                                           | Value               |
-| -------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `dovecot.enabled`                            | Enable dovecot                                                                        | `true`              |
-| `dovecot.logLevel`                           | Override default log level                                                            | `""`                |
-| `dovecot.image.repository`                   | Pod image repository                                                                  | `mailu/dovecot`     |
-| `dovecot.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `dovecot.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `dovecot.persistence.size`                   | Pod pvc size                                                                          | `20Gi`              |
-| `dovecot.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `dovecot.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `dovecot.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `dovecot.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `dovecot.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `dovecot.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `dovecot.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `dovecot.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `dovecot.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `dovecot.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `dovecot.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `dovecot.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `10`                |
-| `dovecot.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `dovecot.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `dovecot.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `dovecot.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `10`                |
-| `dovecot.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `dovecot.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `dovecot.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`             |
-| `dovecot.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `dovecot.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `dovecot.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `10`                |
-| `dovecot.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                 |
-| `dovecot.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `dovecot.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `dovecot.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `dovecot.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `dovecot.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `dovecot.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `dovecot.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `dovecot.affinity`                           | Affinity for dovecot pod assignment                                                   | `{}`                |
-| `dovecot.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `dovecot.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `dovecot.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `dovecot.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `dovecot.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `dovecot.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `dovecot.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `dovecot.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `dovecot.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `dovecot.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `dovecot.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `dovecot.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
-| `dovecot.overrides`                          | Enable dovecot overrides                                                              | `{}`                |
-| `dovecot.compression`                        | Maildir compression algorithm (gz, bz2, lz4, zstd)                                    | `""`                |
-| `dovecot.compressionLevel`                   | Maildir compression level (1-9)                                                       | `6`                 |
+| Name                                            | Description                                                                           | Value               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `dovecot.enabled`                               | Enable dovecot                                                                        | `true`              |
+| `dovecot.logLevel`                              | Override default log level                                                            | `""`                |
+| `dovecot.image.repository`                      | Pod image repository                                                                  | `mailu/dovecot`     |
+| `dovecot.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `dovecot.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `dovecot.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
+| `dovecot.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `dovecot.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `dovecot.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                |
+| `dovecot.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `dovecot.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `dovecot.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `dovecot.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `dovecot.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `dovecot.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `dovecot.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `dovecot.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `dovecot.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `10`                |
+| `dovecot.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `dovecot.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `dovecot.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `dovecot.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `10`                |
+| `dovecot.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `dovecot.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `dovecot.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`             |
+| `dovecot.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `dovecot.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `dovecot.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `10`                |
+| `dovecot.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `3`                 |
+| `dovecot.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `dovecot.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `dovecot.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `dovecot.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `dovecot.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `dovecot.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `dovecot.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `dovecot.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `dovecot.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `dovecot.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `dovecot.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `dovecot.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `dovecot.affinity`                              | Affinity for dovecot pod assignment                                                   | `{}`                |
+| `dovecot.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `dovecot.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
+| `dovecot.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `dovecot.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `dovecot.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `dovecot.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `dovecot.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `dovecot.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `dovecot.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `dovecot.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `dovecot.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `dovecot.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| `dovecot.overrides`                             | Enable dovecot overrides                                                              | `{}`                |
+| `dovecot.compression`                           | Maildir compression algorithm (gz, bz2, lz4, zstd)                                    | `""`                |
+| `dovecot.compressionLevel`                      | Maildir compression level (1-9)                                                       | `6`                 |
 
 ### rspamd parameters
 
-| Name                                        | Description                                                                           | Value               |
-| ------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `rspamd.overrides`                          | Enable rspamd overrides                                                               | `{}`                |
-| `rspamd.antivirusAction`                    | Action to take when an virus is detected. Possible values: `reject` or `discard`      | `discard`           |
-| `rspamd.logLevel`                           | Override default log level                                                            | `""`                |
-| `rspamd.image.repository`                   | Pod image repository                                                                  | `mailu/rspamd`      |
-| `rspamd.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `rspamd.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `rspamd.persistence.size`                   | Pod pvc size                                                                          | `1Gi`               |
-| `rspamd.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `rspamd.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `rspamd.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `rspamd.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `rspamd.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `rspamd.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `rspamd.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `rspamd.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `rspamd.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `rspamd.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `rspamd.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `rspamd.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `rspamd.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `rspamd.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `rspamd.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `rspamd.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `rspamd.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `rspamd.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `rspamd.startupProbe.enabled`               | Enable startupProbe                                                                   | `true`              |
-| `rspamd.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `rspamd.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `rspamd.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `5`                 |
-| `rspamd.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `90`                |
-| `rspamd.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `rspamd.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `rspamd.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `rspamd.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `rspamd.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `rspamd.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `rspamd.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `rspamd.affinity`                           | Affinity for rspamd pod assignment                                                    | `{}`                |
-| `rspamd.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `rspamd.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `rspamd.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `rspamd.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `rspamd.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `rspamd.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `rspamd.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `rspamd.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `rspamd.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `rspamd.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `rspamd.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `rspamd.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| Name                                           | Description                                                                           | Value               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `rspamd.overrides`                             | Enable rspamd overrides                                                               | `{}`                |
+| `rspamd.antivirusAction`                       | Action to take when an virus is detected. Possible values: `reject` or `discard`      | `discard`           |
+| `rspamd.logLevel`                              | Override default log level                                                            | `""`                |
+| `rspamd.image.repository`                      | Pod image repository                                                                  | `mailu/rspamd`      |
+| `rspamd.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `rspamd.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `rspamd.persistence.size`                      | Pod pvc size                                                                          | `1Gi`               |
+| `rspamd.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `rspamd.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `rspamd.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                |
+| `rspamd.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `rspamd.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `rspamd.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `rspamd.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `rspamd.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `rspamd.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `rspamd.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `rspamd.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `rspamd.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                 |
+| `rspamd.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `rspamd.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `rspamd.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `rspamd.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                 |
+| `rspamd.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `rspamd.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `rspamd.startupProbe.enabled`                  | Enable startupProbe                                                                   | `true`              |
+| `rspamd.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `rspamd.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `rspamd.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `5`                 |
+| `rspamd.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `90`                |
+| `rspamd.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `rspamd.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `rspamd.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `rspamd.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `rspamd.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `rspamd.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `rspamd.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `rspamd.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `rspamd.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `rspamd.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `rspamd.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `rspamd.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `rspamd.affinity`                              | Affinity for rspamd pod assignment                                                    | `{}`                |
+| `rspamd.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `rspamd.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
+| `rspamd.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `rspamd.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `rspamd.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `rspamd.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `rspamd.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `rspamd.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `rspamd.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `rspamd.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `rspamd.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `rspamd.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
 ### clamav parameters
 
-| Name                                        | Description                                                                           | Value               |
-| ------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `clamav.enabled`                            | Enable ClamAV                                                                         | `true`              |
-| `clamav.logLevel`                           | Override default log level                                                            | `""`                |
-| `clamav.image.repository`                   | Pod image repository                                                                  | `mailu/clamav`      |
-| `clamav.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `clamav.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `clamav.persistence.enabled`                | Enable persistence using PVC                                                          | `true`              |
-| `clamav.persistence.size`                   | Pod pvc size                                                                          | `2Gi`               |
-| `clamav.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `clamav.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `clamav.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `clamav.persistence.labels`                 | Pod pvc labels                                                                        | `{}`                |
-| `clamav.persistence.selector`               | Additional labels to match for the PVC                                                | `{}`                |
-| `clamav.persistence.dataSource`             | Custom PVC data source                                                                | `{}`                |
-| `clamav.persistence.existingClaim`          | Use a existing PVC which must be created manually before bound                        | `""`                |
-| `clamav.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `clamav.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `clamav.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `clamav.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `clamav.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `clamav.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `clamav.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `clamav.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `clamav.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `clamav.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `clamav.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `clamav.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `clamav.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `clamav.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `clamav.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`             |
-| `clamav.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `clamav.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `clamav.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `5`                 |
-| `clamav.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `60`                |
-| `clamav.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `clamav.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `clamav.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `clamav.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `clamav.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `clamav.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `clamav.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `clamav.affinity`                           | Affinity for clamav pod assignment                                                    | `{}`                |
-| `clamav.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `clamav.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `clamav.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `clamav.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `clamav.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `clamav.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `clamav.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `clamav.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `clamav.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `clamav.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `clamav.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| Name                                           | Description                                                                           | Value               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `clamav.enabled`                               | Enable ClamAV                                                                         | `true`              |
+| `clamav.logLevel`                              | Override default log level                                                            | `""`                |
+| `clamav.image.repository`                      | Pod image repository                                                                  | `mailu/clamav`      |
+| `clamav.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `clamav.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `clamav.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`              |
+| `clamav.persistence.size`                      | Pod pvc size                                                                          | `2Gi`               |
+| `clamav.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `clamav.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `clamav.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `clamav.persistence.labels`                    | Pod pvc labels                                                                        | `{}`                |
+| `clamav.persistence.selector`                  | Additional labels to match for the PVC                                                | `{}`                |
+| `clamav.persistence.dataSource`                | Custom PVC data source                                                                | `{}`                |
+| `clamav.persistence.existingClaim`             | Use a existing PVC which must be created manually before bound                        | `""`                |
+| `clamav.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `clamav.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `clamav.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `clamav.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `clamav.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `clamav.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `clamav.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `clamav.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                 |
+| `clamav.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `clamav.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `clamav.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `clamav.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                 |
+| `clamav.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `clamav.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `clamav.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`             |
+| `clamav.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `clamav.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `clamav.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `5`                 |
+| `clamav.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `60`                |
+| `clamav.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `clamav.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `clamav.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `clamav.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `clamav.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `clamav.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `clamav.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `clamav.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `clamav.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `clamav.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `clamav.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `clamav.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `clamav.affinity`                              | Affinity for clamav pod assignment                                                    | `{}`                |
+| `clamav.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `clamav.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `clamav.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `clamav.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `clamav.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `clamav.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `clamav.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `clamav.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `clamav.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `clamav.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `clamav.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
 ### webmail parameters
 
-| Name                                         | Description                                                                           | Value                                                                             |
-| -------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `webmail.enabled`                            | Enable deployment of Roundcube webmail                                                | `true`                                                                            |
-| `webmail.uri`                                | URI to access Roundcube webmail                                                       | `/webmail`                                                                        |
-| `webmail.type`                               | Type of webmail to deploy (`roundcube` or `snappymail`)                               | `roundcube`                                                                       |
-| `webmail.roundcubePlugins`                   | List of Roundcube plugins to enable                                                   | `["archive","zipdownload","markasjunk","managesieve","enigma","carddav","mailu"]` |
-| `webmail.logLevel`                           | Override default log level                                                            | `""`                                                                              |
-| `webmail.image.repository`                   | Pod image repository                                                                  | `mailu/webmail`                                                                   |
-| `webmail.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                                                                              |
-| `webmail.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`                                                                    |
-| `webmail.persistence.size`                   | Pod pvc size                                                                          | `20Gi`                                                                            |
-| `webmail.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                                                                              |
-| `webmail.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]`                                                               |
-| `webmail.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                                                                              |
-| `webmail.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                                                                              |
-| `webmail.resources.limits`                   | The resources limits for the container                                                | `{}`                                                                              |
-| `webmail.resources.requests`                 | The requested resources for the container                                             | `{}`                                                                              |
-| `webmail.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`                                                                            |
-| `webmail.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                                                                               |
-| `webmail.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                                                                              |
-| `webmail.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                                                                              |
-| `webmail.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                                                                               |
-| `webmail.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                                                                               |
-| `webmail.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`                                                                            |
-| `webmail.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                                                                              |
-| `webmail.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                                                                              |
-| `webmail.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                                                                               |
-| `webmail.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                                                                               |
-| `webmail.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                                                                               |
-| `webmail.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`                                                                           |
-| `webmail.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                                                                              |
-| `webmail.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                                                                              |
-| `webmail.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                                                                               |
-| `webmail.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                                                                               |
-| `webmail.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                                                                               |
-| `webmail.podLabels`                          | Add extra labels to pod                                                               | `{}`                                                                              |
-| `webmail.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                                                                              |
-| `webmail.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                                                                              |
-| `webmail.initContainers`                     | Add additional init containers to the pod                                             | `[]`                                                                              |
-| `webmail.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                                                                              |
-| `webmail.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                                                                               |
-| `webmail.affinity`                           | Affinity for webmail pod assignment                                                   | `{}`                                                                              |
-| `webmail.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                                                                              |
-| `webmail.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                                                                               |
-| `webmail.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                                                                              |
-| `webmail.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                                                                              |
-| `webmail.service.annotations`                | Admin service annotations                                                             | `{}`                                                                              |
-| `webmail.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                                                                              |
-| `webmail.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`                                                                   |
-| `webmail.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                                                                              |
-| `webmail.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                                                                              |
-| `webmail.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                                                                              |
-| `webmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                                                                              |
-| `webmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                                                                              |
+| Name                                            | Description                                                                           | Value                                                                             |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `webmail.enabled`                               | Enable deployment of Roundcube webmail                                                | `true`                                                                            |
+| `webmail.uri`                                   | URI to access Roundcube webmail                                                       | `/webmail`                                                                        |
+| `webmail.type`                                  | Type of webmail to deploy (`roundcube` or `snappymail`)                               | `roundcube`                                                                       |
+| `webmail.roundcubePlugins`                      | List of Roundcube plugins to enable                                                   | `["archive","zipdownload","markasjunk","managesieve","enigma","carddav","mailu"]` |
+| `webmail.logLevel`                              | Override default log level                                                            | `""`                                                                              |
+| `webmail.image.repository`                      | Pod image repository                                                                  | `mailu/webmail`                                                                   |
+| `webmail.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                                                                              |
+| `webmail.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`                                                                    |
+| `webmail.persistence.size`                      | Pod pvc size                                                                          | `20Gi`                                                                            |
+| `webmail.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                                                                              |
+| `webmail.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]`                                                               |
+| `webmail.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                                                                              |
+| `webmail.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                                                                              |
+| `webmail.resources.limits`                      | The resources limits for the container                                                | `{}`                                                                              |
+| `webmail.resources.requests`                    | The requested resources for the container                                             | `{}`                                                                              |
+| `webmail.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`                                                                            |
+| `webmail.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                                                                               |
+| `webmail.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                                                                              |
+| `webmail.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                                                                              |
+| `webmail.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                                                                               |
+| `webmail.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                                                                               |
+| `webmail.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`                                                                            |
+| `webmail.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                                                                              |
+| `webmail.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                                                                              |
+| `webmail.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                                                                               |
+| `webmail.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                                                                               |
+| `webmail.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                                                                               |
+| `webmail.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`                                                                           |
+| `webmail.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                                                                              |
+| `webmail.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                                                                              |
+| `webmail.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `1`                                                                               |
+| `webmail.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `3`                                                                               |
+| `webmail.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                                                                               |
+| `webmail.podLabels`                             | Add extra labels to pod                                                               | `{}`                                                                              |
+| `webmail.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                                                                              |
+| `webmail.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                                                                              |
+| `webmail.initContainers`                        | Add additional init containers to the pod                                             | `[]`                                                                              |
+| `webmail.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                                                                              |
+| `webmail.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`                                                                           |
+| `webmail.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`                                                                            |
+| `webmail.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`                                                                           |
+| `webmail.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`                                                                            |
+| `webmail.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`                                                                           |
+| `webmail.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                                                                               |
+| `webmail.affinity`                              | Affinity for webmail pod assignment                                                   | `{}`                                                                              |
+| `webmail.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                                                                              |
+| `webmail.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                                                                               |
+| `webmail.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                                                                              |
+| `webmail.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                                                                              |
+| `webmail.service.annotations`                   | Admin service annotations                                                             | `{}`                                                                              |
+| `webmail.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                                                                              |
+| `webmail.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`                                                                   |
+| `webmail.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                                                                              |
+| `webmail.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                                                                              |
+| `webmail.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                                                                              |
+| `webmail.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                                                                              |
+| `webmail.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                                                                              |
 
 ### webdav parameters
 
-| Name                                        | Description                                                                           | Value               |
-| ------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `webdav.enabled`                            | Enable deployment of WebDAV server (using Radicale)                                   | `false`             |
-| `webdav.logLevel`                           | Override default log level                                                            | `""`                |
-| `webdav.image.repository`                   | Pod image repository                                                                  | `mailu/radicale`    |
-| `webdav.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `webdav.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `webdav.persistence.size`                   | Pod pvc size                                                                          | `20Gi`              |
-| `webdav.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `webdav.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `webdav.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `webdav.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `webdav.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `webdav.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `webdav.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `webdav.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `webdav.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `webdav.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `webdav.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `webdav.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `webdav.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `webdav.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `webdav.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `webdav.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `webdav.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `webdav.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `webdav.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`             |
-| `webdav.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `webdav.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `webdav.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                 |
-| `webdav.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                 |
-| `webdav.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `webdav.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `webdav.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `webdav.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `webdav.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `webdav.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `webdav.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `webdav.affinity`                           | Affinity for webdav pod assignment                                                    | `{}`                |
-| `webdav.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `webdav.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `webdav.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `webdav.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `webdav.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `webdav.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `webdav.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `webdav.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `webdav.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `webdav.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `webdav.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `webdav.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| Name                                           | Description                                                                           | Value               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `webdav.enabled`                               | Enable deployment of WebDAV server (using Radicale)                                   | `false`             |
+| `webdav.logLevel`                              | Override default log level                                                            | `""`                |
+| `webdav.image.repository`                      | Pod image repository                                                                  | `mailu/radicale`    |
+| `webdav.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `webdav.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `webdav.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
+| `webdav.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `webdav.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `webdav.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                |
+| `webdav.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `webdav.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `webdav.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `webdav.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `webdav.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `webdav.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `webdav.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `webdav.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `webdav.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                 |
+| `webdav.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `webdav.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `webdav.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `webdav.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                 |
+| `webdav.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `webdav.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `webdav.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`             |
+| `webdav.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `webdav.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `webdav.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `1`                 |
+| `webdav.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `3`                 |
+| `webdav.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `webdav.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `webdav.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `webdav.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `webdav.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `webdav.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `webdav.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `webdav.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `webdav.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `webdav.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `webdav.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `webdav.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `webdav.affinity`                              | Affinity for webdav pod assignment                                                    | `{}`                |
+| `webdav.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `webdav.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
+| `webdav.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `webdav.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `webdav.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `webdav.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `webdav.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `webdav.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `webdav.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `webdav.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `webdav.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `webdav.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
 ### fetchmail parameters
 
-| Name                                           | Description                                                                           | Value               |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| `fetchmail.enabled`                            | Enable deployment of fetchmail                                                        | `false`             |
-| `fetchmail.delay`                              | Delay between fetchmail runs                                                          | `600`               |
-| `fetchmail.logLevel`                           | Override default log level                                                            | `""`                |
-| `fetchmail.image.repository`                   | Pod image repository                                                                  | `mailu/fetchmail`   |
-| `fetchmail.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
-| `fetchmail.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`      |
-| `fetchmail.persistence.size`                   | Pod pvc size                                                                          | `20Gi`              |
-| `fetchmail.persistence.storageClass`           | Pod pvc storage class                                                                 | `""`                |
-| `fetchmail.persistence.accessModes`            | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
-| `fetchmail.persistence.claimNameOverride`      | Pod pvc name override                                                                 | `""`                |
-| `fetchmail.persistence.annotations`            | Pod pvc annotations                                                                   | `{}`                |
-| `fetchmail.resources.limits`                   | The resources limits for the container                                                | `{}`                |
-| `fetchmail.resources.requests`                 | The requested resources for the container                                             | `{}`                |
-| `fetchmail.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`              |
-| `fetchmail.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`                 |
-| `fetchmail.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`                |
-| `fetchmail.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`                |
-| `fetchmail.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`                 |
-| `fetchmail.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `1`                 |
-| `fetchmail.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`              |
-| `fetchmail.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`                |
-| `fetchmail.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`                |
-| `fetchmail.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `1`                 |
-| `fetchmail.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`                 |
-| `fetchmail.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`                 |
-| `fetchmail.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`             |
-| `fetchmail.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`                |
-| `fetchmail.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`                |
-| `fetchmail.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `1`                 |
-| `fetchmail.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`                 |
-| `fetchmail.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`                 |
-| `fetchmail.podLabels`                          | Add extra labels to pod                                                               | `{}`                |
-| `fetchmail.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`                |
-| `fetchmail.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`                |
-| `fetchmail.initContainers`                     | Add additional init containers to the pod                                             | `[]`                |
-| `fetchmail.priorityClassName`                  | Pods' priorityClassName                                                               | `""`                |
-| `fetchmail.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `fetchmail.affinity`                           | Affinity for fetchmail pod assignment                                                 | `{}`                |
-| `fetchmail.tolerations`                        | Tolerations for pod assignment                                                        | `[]`                |
-| `fetchmail.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
-| `fetchmail.hostAliases`                        | Pod pod host aliases                                                                  | `[]`                |
-| `fetchmail.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`                |
-| `fetchmail.service.annotations`                | Admin service annotations                                                             | `{}`                |
-| `fetchmail.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`                |
-| `fetchmail.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
-| `fetchmail.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`                |
-| `fetchmail.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
-| `fetchmail.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
-| `fetchmail.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
-| `fetchmail.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
+| Name                                              | Description                                                                           | Value               |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `fetchmail.enabled`                               | Enable deployment of fetchmail                                                        | `false`             |
+| `fetchmail.delay`                                 | Delay between fetchmail runs                                                          | `600`               |
+| `fetchmail.logLevel`                              | Override default log level                                                            | `""`                |
+| `fetchmail.image.repository`                      | Pod image repository                                                                  | `mailu/fetchmail`   |
+| `fetchmail.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
+| `fetchmail.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `fetchmail.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
+| `fetchmail.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
+| `fetchmail.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
+| `fetchmail.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                |
+| `fetchmail.persistence.annotations`               | Pod pvc annotations                                                                   | `{}`                |
+| `fetchmail.resources.limits`                      | The resources limits for the container                                                | `{}`                |
+| `fetchmail.resources.requests`                    | The requested resources for the container                                             | `{}`                |
+| `fetchmail.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`              |
+| `fetchmail.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                 |
+| `fetchmail.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                |
+| `fetchmail.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                |
+| `fetchmail.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                 |
+| `fetchmail.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `1`                 |
+| `fetchmail.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`              |
+| `fetchmail.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`                |
+| `fetchmail.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`                |
+| `fetchmail.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `1`                 |
+| `fetchmail.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`                 |
+| `fetchmail.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`                 |
+| `fetchmail.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`             |
+| `fetchmail.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`                |
+| `fetchmail.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`                |
+| `fetchmail.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `1`                 |
+| `fetchmail.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `3`                 |
+| `fetchmail.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`                 |
+| `fetchmail.podLabels`                             | Add extra labels to pod                                                               | `{}`                |
+| `fetchmail.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`                |
+| `fetchmail.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`                |
+| `fetchmail.initContainers`                        | Add additional init containers to the pod                                             | `[]`                |
+| `fetchmail.priorityClassName`                     | Pods' priorityClassName                                                               | `""`                |
+| `fetchmail.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`             |
+| `fetchmail.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`              |
+| `fetchmail.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`             |
+| `fetchmail.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
+| `fetchmail.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
+| `fetchmail.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `fetchmail.affinity`                              | Affinity for fetchmail pod assignment                                                 | `{}`                |
+| `fetchmail.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
+| `fetchmail.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
+| `fetchmail.hostAliases`                           | Pod pod host aliases                                                                  | `[]`                |
+| `fetchmail.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`                |
+| `fetchmail.service.annotations`                   | Admin service annotations                                                             | `{}`                |
+| `fetchmail.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`                |
+| `fetchmail.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`     |
+| `fetchmail.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`                |
+| `fetchmail.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`                |
+| `fetchmail.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`                |
+| `fetchmail.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`                |
+| `fetchmail.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`                |
 
 ### OLETools parameters
 
-| Name                                          | Description                                                                           | Value            |
-| --------------------------------------------- | ------------------------------------------------------------------------------------- | ---------------- |
-| `oletools.enabled`                            | Enable OLETools                                                                       | `true`           |
-| `oletools.logLevel`                           | Override default log level                                                            | `""`             |
-| `oletools.image.repository`                   | Pod image repository                                                                  | `mailu/oletools` |
-| `oletools.image.tag`                          | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`             |
-| `oletools.image.pullPolicy`                   | Pod image pull policy                                                                 | `IfNotPresent`   |
-| `oletools.resources.limits`                   | The resources limits for the container                                                | `{}`             |
-| `oletools.resources.requests`                 | The requested resources for the container                                             | `{}`             |
-| `oletools.livenessProbe.enabled`              | Enable livenessProbe                                                                  | `true`           |
-| `oletools.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                   | `3`              |
-| `oletools.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                               | `10`             |
-| `oletools.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                      | `10`             |
-| `oletools.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                   | `1`              |
-| `oletools.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                     | `5`              |
-| `oletools.readinessProbe.enabled`             | Enable readinessProbe                                                                 | `true`           |
-| `oletools.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                              | `10`             |
-| `oletools.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                     | `10`             |
-| `oletools.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                    | `5`              |
-| `oletools.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                  | `3`              |
-| `oletools.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                  | `1`              |
-| `oletools.startupProbe.enabled`               | Enable startupProbe                                                                   | `false`          |
-| `oletools.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                | `10`             |
-| `oletools.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                       | `10`             |
-| `oletools.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                      | `5`              |
-| `oletools.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                    | `3`              |
-| `oletools.startupProbe.successThreshold`      | Success threshold for startupProbe                                                    | `1`              |
-| `oletools.podLabels`                          | Add extra labels to pod                                                               | `{}`             |
-| `oletools.podAnnotations`                     | Add extra annotations to the pod                                                      | `{}`             |
-| `oletools.nodeSelector`                       | Node labels selector for pod assignment                                               | `{}`             |
-| `oletools.initContainers`                     | Add additional init containers to the pod                                             | `[]`             |
-| `oletools.priorityClassName`                  | Pods' priorityClassName                                                               | `""`             |
-| `oletools.terminationGracePeriodSeconds`      | In seconds, time given to the pod to terminate gracefully                             | `2`              |
-| `oletools.affinity`                           | Affinity for oletools pod assignment                                                  | `{}`             |
-| `oletools.tolerations`                        | Tolerations for pod assignment                                                        | `[]`             |
-| `oletools.revisionHistoryLimit`               | Configure the revisionHistoryLimit of the deployment                                  | `3`              |
-| `oletools.hostAliases`                        | Pod pod host aliases                                                                  | `[]`             |
-| `oletools.schedulerName`                      | Name of the k8s scheduler (other than default)                                        | `""`             |
-| `oletools.service.annotations`                | oletools service annotations                                                          | `{}`             |
-| `oletools.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                        | `[]`             |
-| `oletools.updateStrategy.type`                | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`  |
-| `oletools.extraEnvVars`                       | Extra environment variable to pass to the running container                           | `[]`             |
-| `oletools.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`             |
-| `oletools.extraEnvVarsSecret`                 | Name of existing Secret containing extra environment variables to mount in the pod    | `""`             |
-| `oletools.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`             |
-| `oletools.extraVolumes`                       | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`             |
+| Name                                             | Description                                                                           | Value            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------------- |
+| `oletools.enabled`                               | Enable OLETools                                                                       | `true`           |
+| `oletools.logLevel`                              | Override default log level                                                            | `""`             |
+| `oletools.image.repository`                      | Pod image repository                                                                  | `mailu/oletools` |
+| `oletools.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`             |
+| `oletools.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`   |
+| `oletools.resources.limits`                      | The resources limits for the container                                                | `{}`             |
+| `oletools.resources.requests`                    | The requested resources for the container                                             | `{}`             |
+| `oletools.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`           |
+| `oletools.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`              |
+| `oletools.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`             |
+| `oletools.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`             |
+| `oletools.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`              |
+| `oletools.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                     | `5`              |
+| `oletools.readinessProbe.enabled`                | Enable readinessProbe                                                                 | `true`           |
+| `oletools.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                              | `10`             |
+| `oletools.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                     | `10`             |
+| `oletools.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                    | `5`              |
+| `oletools.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                  | `3`              |
+| `oletools.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                  | `1`              |
+| `oletools.startupProbe.enabled`                  | Enable startupProbe                                                                   | `false`          |
+| `oletools.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                | `10`             |
+| `oletools.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                       | `10`             |
+| `oletools.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                      | `5`              |
+| `oletools.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                    | `3`              |
+| `oletools.startupProbe.successThreshold`         | Success threshold for startupProbe                                                    | `1`              |
+| `oletools.podLabels`                             | Add extra labels to pod                                                               | `{}`             |
+| `oletools.podAnnotations`                        | Add extra annotations to the pod                                                      | `{}`             |
+| `oletools.nodeSelector`                          | Node labels selector for pod assignment                                               | `{}`             |
+| `oletools.initContainers`                        | Add additional init containers to the pod                                             | `[]`             |
+| `oletools.priorityClassName`                     | Pods' priorityClassName                                                               | `""`             |
+| `oletools.podSecurityContext.enabled`            | Enabled pods' Security Context                                                        | `false`          |
+| `oletools.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                    | `1001`           |
+| `oletools.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                  | `false`          |
+| `oletools.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`           |
+| `oletools.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`          |
+| `oletools.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`              |
+| `oletools.affinity`                              | Affinity for oletools pod assignment                                                  | `{}`             |
+| `oletools.tolerations`                           | Tolerations for pod assignment                                                        | `[]`             |
+| `oletools.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`              |
+| `oletools.hostAliases`                           | Pod pod host aliases                                                                  | `[]`             |
+| `oletools.schedulerName`                         | Name of the k8s scheduler (other than default)                                        | `""`             |
+| `oletools.service.annotations`                   | oletools service annotations                                                          | `{}`             |
+| `oletools.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                        | `[]`             |
+| `oletools.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                               | `RollingUpdate`  |
+| `oletools.extraEnvVars`                          | Extra environment variable to pass to the running container                           | `[]`             |
+| `oletools.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod | `""`             |
+| `oletools.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod    | `""`             |
+| `oletools.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                  | `[]`             |
+| `oletools.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`             |
 
 
 ## Example values.yaml to get started

--- a/mailu/templates/admin/deployment.yaml
+++ b/mailu/templates/admin/deployment.yaml
@@ -60,10 +60,16 @@ spec:
       {{- if .Values.admin.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.admin.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.admin.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.admin.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: admin
           image: {{ .Values.imageRegistry }}/{{ .Values.admin.image.repository }}:{{ default (include "mailu.version" .) .Values.admin.image.tag }}
           imagePullPolicy: {{ .Values.admin.image.pullPolicy }}
+          {{- if .Values.admin.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.admin.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               subPath: admin

--- a/mailu/templates/clamav/statefulset.yaml
+++ b/mailu/templates/clamav/statefulset.yaml
@@ -62,10 +62,16 @@ spec:
       {{- if .Values.clamav.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.clamav.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.clamav.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.clamav.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: clamav
           image: {{ .Values.imageRegistry }}/{{ .Values.clamav.image.repository }}:{{ default (include "mailu.version" .) .Values.clamav.image.tag }}
           imagePullPolicy: {{ .Values.clamav.image.pullPolicy }}
+          {{- if .Values.clamav.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.clamav.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               subPath: clamav

--- a/mailu/templates/dovecot/deployment.yaml
+++ b/mailu/templates/dovecot/deployment.yaml
@@ -61,11 +61,15 @@ spec:
       {{- if .Values.dovecot.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.dovecot.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.dovecot.podSecurityContext }}
+      securityContext:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: dovecot
           image: {{ .Values.imageRegistry }}/{{ .Values.dovecot.image.repository }}:{{ default (include "mailu.version" .) .Values.dovecot.image.tag }}
           imagePullPolicy: {{ .Values.dovecot.image.pullPolicy }}
-          {{- with .Values.dovecot.containerSecurityContext }}
+          {{- with .Values.dovecot.securityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}
           {{- end }}

--- a/mailu/templates/dovecot/deployment.yaml
+++ b/mailu/templates/dovecot/deployment.yaml
@@ -65,6 +65,10 @@ spec:
         - name: dovecot
           image: {{ .Values.imageRegistry }}/{{ .Values.dovecot.image.repository }}:{{ default (include "mailu.version" .) .Values.dovecot.image.tag }}
           imagePullPolicy: {{ .Values.dovecot.image.pullPolicy }}
+          {{- with .Values.dovecot.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               subPath: dovecotdata

--- a/mailu/templates/dovecot/deployment.yaml
+++ b/mailu/templates/dovecot/deployment.yaml
@@ -61,17 +61,15 @@ spec:
       {{- if .Values.dovecot.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.dovecot.initContainers "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.dovecot.podSecurityContext }}
-      securityContext:
-        {{- . | toYaml | nindent 8 }}
+      {{- if .Values.dovecot.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.dovecot.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: dovecot
           image: {{ .Values.imageRegistry }}/{{ .Values.dovecot.image.repository }}:{{ default (include "mailu.version" .) .Values.dovecot.image.tag }}
           imagePullPolicy: {{ .Values.dovecot.image.pullPolicy }}
-          {{- with .Values.dovecot.securityContext }}
-          securityContext:
-            {{- . | toYaml | nindent 12 }}
+          {{- if .Values.dovecot.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.dovecot.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: data

--- a/mailu/templates/fetchmail/deployment.yaml
+++ b/mailu/templates/fetchmail/deployment.yaml
@@ -61,10 +61,16 @@ spec:
       {{- if .Values.fetchmail.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.fetchmail.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.fetchmail.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.fetchmail.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: fetchmail
           image: {{ .Values.imageRegistry }}/{{ .Values.fetchmail.image.repository }}:{{ default (include "mailu.version" .) .Values.fetchmail.image.tag }}
           imagePullPolicy: {{ .Values.fetchmail.image.pullPolicy }}
+          {{- if .Values.fetchmail.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.fetchmail.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               subPath: fetchmail

--- a/mailu/templates/front/deployment.yaml
+++ b/mailu/templates/front/deployment.yaml
@@ -65,10 +65,16 @@ spec:
       {{- if .Values.front.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.front.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.front.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.front.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: front
           image: {{ .Values.imageRegistry }}/{{ .Values.front.image.repository }}:{{ default (include "mailu.version" .) .Values.front.image.tag }}
           imagePullPolicy: {{ .Values.front.image.pullPolicy }}
+          {{- if .Values.front.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.front.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: certs
               mountPath: /certs

--- a/mailu/templates/oletools/deployment.yaml
+++ b/mailu/templates/oletools/deployment.yaml
@@ -61,10 +61,16 @@ spec:
       {{- if .Values.oletools.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.oletools.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.oletools.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.oletools.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: oletools
           image: {{ .Values.imageRegistry }}/{{ .Values.oletools.image.repository }}:{{ default (include "mailu.version" .) .Values.oletools.image.tag }}
           imagePullPolicy: {{ .Values.oletools.image.pullPolicy }}
+          {{- if .Values.oletools.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.oletools.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.oletools.extraVolumeMounts }}
           volumeMounts:
             {{- include "common.tplvalues.render" (dict "value" .Values.oletools.extraVolumeMounts "context" $) | nindent 12 }}

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -60,17 +60,15 @@ spec:
       {{- if .Values.postfix.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.postfix.initContainers "context" $) | nindent 8 }}
       {{- end }}
-      {{- with .Values.postfix.podSecurityContext }}
-      securityContext:
-        {{- . | toYaml | nindent 8 }}
+      {{- if .Values.postfix.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.postfix.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: postfix
           image: {{ .Values.imageRegistry }}/{{ .Values.postfix.image.repository }}:{{ default (include "mailu.version" .) .Values.postfix.image.tag }}
           imagePullPolicy: {{ .Values.postfix.image.pullPolicy }}
-          {{- with .Values.postfix.securityContext }}
-          securityContext:
-            {{- . | toYaml | nindent 12 }}
+          {{- if .Values.postfix.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.postfix.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /queue

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -64,6 +64,10 @@ spec:
         - name: postfix
           image: {{ .Values.imageRegistry }}/{{ .Values.postfix.image.repository }}:{{ default (include "mailu.version" .) .Values.postfix.image.tag }}
           imagePullPolicy: {{ .Values.postfix.image.pullPolicy }}
+          {{- with .Values.postfix.containerSecurityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /queue
               name: data

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -60,11 +60,15 @@ spec:
       {{- if .Values.postfix.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.postfix.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- with .Values.postfix.podSecurityContext }}
+      securityContext:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: postfix
           image: {{ .Values.imageRegistry }}/{{ .Values.postfix.image.repository }}:{{ default (include "mailu.version" .) .Values.postfix.image.tag }}
           imagePullPolicy: {{ .Values.postfix.image.pullPolicy }}
-          {{- with .Values.postfix.containerSecurityContext }}
+          {{- with .Values.postfix.securityContext }}
           securityContext:
             {{- . | toYaml | nindent 12 }}
           {{- end }}

--- a/mailu/templates/rspamd/deployment.yaml
+++ b/mailu/templates/rspamd/deployment.yaml
@@ -60,11 +60,17 @@ spec:
       {{- if .Values.rspamd.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.rspamd.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.rspamd.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.rspamd.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       hostname: rspamd # https://github.com/Mailu/helm-charts/issues/95
       containers:
         - name: rspamd
           image: {{ .Values.imageRegistry }}/{{ .Values.rspamd.image.repository }}:{{ default (include "mailu.version" .) .Values.rspamd.image.tag }}
           imagePullPolicy: {{ .Values.rspamd.image.pullPolicy }}
+          {{- if .Values.rspamd.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.rspamd.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               subPath: rspamd

--- a/mailu/templates/webdav/deployment.yaml
+++ b/mailu/templates/webdav/deployment.yaml
@@ -61,10 +61,16 @@ spec:
       {{- if .Values.webdav.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.webdav.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.webdav.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.webdav.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: webdav
           image: {{ .Values.imageRegistry }}/{{ .Values.webdav.image.repository }}:{{ default (include "mailu.version" .) .Values.webdav.image.tag }}
           imagePullPolicy: {{ .Values.webdav.image.pullPolicy }}
+          {{- if .Values.webdav.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.webdav.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               subPath: webdav

--- a/mailu/templates/webmail/deployment.yaml
+++ b/mailu/templates/webmail/deployment.yaml
@@ -61,10 +61,16 @@ spec:
       {{- if .Values.webmail.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.webmail.initContainers "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.webmail.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.webmail.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: webmail
           image: {{ .Values.imageRegistry }}/{{ .Values.webmail.image.repository }}:{{ default (include "mailu.version" .) .Values.webmail.image.tag }}
           imagePullPolicy: {{ .Values.webmail.image.pullPolicy }}
+          {{- if .Values.webmail.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.webmail.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /data
               name: data

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -769,6 +769,22 @@ front:
   ## @param front.priorityClassName Pods' priorityClassName
   priorityClassName: ""
 
+  ## @param front.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param front.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param front.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param front.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param front.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
+
   ## @param front.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
@@ -954,6 +970,22 @@ admin:
 
   ## @param admin.priorityClassName Pods' priorityClassName
   priorityClassName: ""
+
+  ## @param admin.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param admin.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param admin.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param admin.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param admin.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
 
   ## @param admin.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
@@ -1175,6 +1207,22 @@ postfix:
   ## @param postfix.priorityClassName Pods' priorityClassName
   priorityClassName: ""
 
+  ## @param postfix.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param postfix.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param postfix.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param postfix.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param postfix.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
+
   ## @param postfix.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
@@ -1239,11 +1287,6 @@ postfix:
   ##   postfix.cf: |
   ##     my_variable = my_value
   overrides: {}
-
-  ## @param postfix.securityContext `securityContext` for postfix container
-  securityContext: {}
-  ## @param postfix.podSecurityContext `securityContext` for postfix pod
-  podSecurityContext: {}
 
 ## @section Dovecot parameters
 dovecot:
@@ -1369,6 +1412,22 @@ dovecot:
   ## @param dovecot.priorityClassName Pods' priorityClassName
   priorityClassName: ""
 
+  ## @param dovecot.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param dovecot.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param dovecot.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param dovecot.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param dovecot.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
+
   ## @param dovecot.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
@@ -1443,11 +1502,6 @@ dovecot:
 
   ## @param dovecot.compressionLevel Maildir compression level (1-9)
   compressionLevel: 6
-
-  ## @param dovecot.securityContext `securityContext` for dovecot container
-  securityContext: {}
-  ## @param dovecot.podSecurityContext `securityContext` for dovecot pod
-  podSecurityContext: {}
 
 ## @section rspamd parameters
 rspamd:
@@ -1583,6 +1637,22 @@ rspamd:
 
   ## @param rspamd.priorityClassName Pods' priorityClassName
   priorityClassName: ""
+
+  ## @param rspamd.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param rspamd.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param rspamd.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param rspamd.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param rspamd.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
 
   ## @param rspamd.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
@@ -1786,6 +1856,22 @@ clamav:
 
   ## @param clamav.priorityClassName Pods' priorityClassName
   priorityClassName: ""
+
+  ## @param clamav.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param clamav.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param clamav.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param clamav.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param clamav.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
 
   ## @param clamav.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
@@ -1992,6 +2078,22 @@ webmail:
   ## @param webmail.priorityClassName Pods' priorityClassName
   priorityClassName: ""
 
+  ## @param webmail.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param webmail.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param webmail.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param webmail.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param webmail.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
+
   ## @param webmail.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
@@ -2172,6 +2274,22 @@ webdav:
 
   ## @param webdav.priorityClassName Pods' priorityClassName
   priorityClassName: ""
+
+  ## @param webdav.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param webdav.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param webdav.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param webdav.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param webdav.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
 
   ## @param webdav.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
@@ -2357,6 +2475,22 @@ fetchmail:
   ## @param fetchmail.priorityClassName Pods' priorityClassName
   priorityClassName: ""
 
+  ## @param fetchmail.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param fetchmail.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param fetchmail.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param fetchmail.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param fetchmail.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
+
   ## @param fetchmail.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
@@ -2524,6 +2658,22 @@ oletools:
 
   ## @param oletools.priorityClassName Pods' priorityClassName
   priorityClassName: ""
+
+  ## @param oletools.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param oletools.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param oletools.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param oletools.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param oletools.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
 
   ## @param oletools.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1240,8 +1240,10 @@ postfix:
   ##     my_variable = my_value
   overrides: {}
 
-  ## @param postfix.containerSecurityContext `securityContext` for postfix container
-  containerSecurityContext: {}
+  ## @param postfix.securityContext `securityContext` for postfix container
+  securityContext: {}
+  ## @param postfix.securityContext `securityContext` for postfix pod
+  podSecurityContext: {}
 
 ## @section Dovecot parameters
 dovecot:
@@ -1442,8 +1444,10 @@ dovecot:
   ## @param dovecot.compressionLevel Maildir compression level (1-9)
   compressionLevel: 6
 
-  ## @param dovecot.containerSecurityContext `securityContext` for dovecot container
-  containerSecurityContext: {}
+  ## @param dovecot.securityContext `securityContext` for dovecot container
+  securityContext: {}
+  ## @param dovecot.podSecurityContext `securityContext` for dovecot pod
+  podSecurityContext: {}
 
 ## @section rspamd parameters
 rspamd:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1240,6 +1240,9 @@ postfix:
   ##     my_variable = my_value
   overrides: {}
 
+  ## @param postfix.containerSecurityContext `securityContext` for postfix container
+  containerSecurityContext: {}
+
 ## @section Dovecot parameters
 dovecot:
   ## @param dovecot.enabled Enable dovecot
@@ -1438,6 +1441,9 @@ dovecot:
 
   ## @param dovecot.compressionLevel Maildir compression level (1-9)
   compressionLevel: 6
+
+  ## @param dovecot.containerSecurityContext `securityContext` for dovecot container
+  containerSecurityContext: {}
 
 ## @section rspamd parameters
 rspamd:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1242,7 +1242,7 @@ postfix:
 
   ## @param postfix.securityContext `securityContext` for postfix container
   securityContext: {}
-  ## @param postfix.securityContext `securityContext` for postfix pod
+  ## @param postfix.podSecurityContext `securityContext` for postfix pod
   podSecurityContext: {}
 
 ## @section Dovecot parameters


### PR DESCRIPTION
Postfix and Dovecot sometimes need capabilities that some CRIs, such as cri-o, do not support by default, e.g. `SYS_CHROOT`. In these cases, if these capabilities are not added explicitly, postfix and dovecot won't start.

This commit adds `.Values.{postfix,dovecot}.containerSecurityContext` to values.yaml and to the corresponding templates.

This PR is effectively the same as https://github.com/Mailu/helm-charts/pull/125, which seems to have been lost in the 1.x migration.