### PR TITLE
Fixed no secret error if webmail is disabled

### DIFF
--- a/mailu/templates/_secrets.tpl
+++ b/mailu/templates/_secrets.tpl
@@ -68,11 +68,13 @@
     secretKeyRef:
       name: {{ include "mailu.database.secretName" . }}
       key: {{ include "mailu.database.secretKey" . }}
+{{- if and .Values.webmail.enabled (eq .Values.webmail.type "roundcube") }}
 - name: ROUNDCUBE_DB_PW
   valueFrom:
     secretKeyRef:
       name: {{ include "mailu.database.roundcube.secretName" . }}
       key: {{ include "mailu.database.roundcube.secretKey" . }}
+{{- end }}
 {{- end }}
 {{- if .Values.externalRelay.host }}
 - name: RELAYUSER


### PR DESCRIPTION
I have received `ContainerCreationError` for all containers who use this secrets template. There is no secret created if you do not enable webmail.