### PR TITLE
fix: only include roudcube secrets if webmail.enabled is set to true

### DIFF
--- a/mailu/templates/_secrets.tpl
+++ b/mailu/templates/_secrets.tpl
@@ -68,6 +68,8 @@
     secretKeyRef:
       name: {{ include "mailu.database.secretName" . }}
       key: {{ include "mailu.database.secretKey" . }}
+{{- end }}
+{{- if .Values.webmail.enabled }}
 - name: ROUNDCUBE_DB_PW
   valueFrom:
     secretKeyRef:

--- a/mailu/templates/envvars-configmap.yaml
+++ b/mailu/templates/envvars-configmap.yaml
@@ -106,9 +106,11 @@ data:
 
 
 {{- if not (eq (include "mailu.database.type" .) "sqlite") }}
+{{- if .Values.webmail.enabled }}
   ROUNDCUBE_DB_USER: {{ include "mailu.database.roundcube.username" . }}
   ROUNDCUBE_DB_NAME: {{ include "mailu.database.roundcube.name" . }}
   ROUNDCUBE_DB_HOST: {{ printf "%s:%s" (include "mailu.database.host" .) (include "mailu.database.port" .) | quote}}
+{{- end }}
 {{- end }}
 
 {{- if .Values.initialAccount.enabled }}


### PR DESCRIPTION
This is to fix https://github.com/Mailu/helm-charts/issues/259 where you get:
```
Error: secret "mailu-roundcube" not found when "webmail.enabled" is false
```

Not sure if I need to bump the helm chart version, but happy to do so.