### PR TITLE
fix: readinessProbe.enabled has no effect

### DIFF
--- a/mailu/templates/admin/deployment.yaml
+++ b/mailu/templates/admin/deployment.yaml
@@ -113,7 +113,7 @@ spec:
               path: /sso/login
               port: http
           {{- end }}
-          {{- if .Values.admin.readinessProbe }}
+          {{- if .Values.admin.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.admin.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /sso/login

--- a/mailu/templates/clamav/statefulset.yaml
+++ b/mailu/templates/clamav/statefulset.yaml
@@ -108,7 +108,7 @@ spec:
             exec:
               command: ["echo", "PING", "|", "nc", "localhost", "3310", "|", "grep", "PONG"]
           {{- end }}
-          {{- if .Values.clamav.readinessProbe }}
+          {{- if .Values.clamav.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clamav.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: ["echo", "PING", "|", "nc", "localhost", "3310", "|", "grep", "PONG"]

--- a/mailu/templates/fetchmail/deployment.yaml
+++ b/mailu/templates/fetchmail/deployment.yaml
@@ -115,7 +115,7 @@ spec:
             exec:
               command: [ "true" ]
           {{- end }}
-          {{- if .Values.fetchmail.readinessProbe }}
+          {{- if .Values.fetchmail.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.fetchmail.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: [ "true" ]

--- a/mailu/templates/front/deployment.yaml
+++ b/mailu/templates/front/deployment.yaml
@@ -171,7 +171,7 @@ spec:
               path: /health
               port: http
           {{- end }}
-          {{- if .Values.front.readinessProbe }}
+          {{- if .Values.front.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.front.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /health

--- a/mailu/templates/oletools/deployment.yaml
+++ b/mailu/templates/oletools/deployment.yaml
@@ -109,7 +109,7 @@ spec:
                 - -c
                 - 'echo PING|nc -q1 localhost 11343|grep PONG'
           {{- end }}
-          {{- if .Values.oletools.readinessProbe }}
+          {{- if .Values.oletools.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.oletools.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -125,7 +125,7 @@ spec:
                 - -c
                 - 'echo QUIT|nc localhost 25|grep "220 .* ESMTP Postfix"'
           {{- end }}
-          {{- if .Values.postfix.readinessProbe }}
+          {{- if .Values.postfix.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.postfix.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:

--- a/mailu/templates/rspamd/deployment.yaml
+++ b/mailu/templates/rspamd/deployment.yaml
@@ -119,7 +119,7 @@ spec:
               path: /
               port: rspamd-http
           {{- end }}
-          {{- if .Values.rspamd.readinessProbe }}
+          {{- if .Values.rspamd.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.rspamd.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /

--- a/mailu/templates/webdav/deployment.yaml
+++ b/mailu/templates/webdav/deployment.yaml
@@ -109,7 +109,7 @@ spec:
               path: /
               port: http
           {{- end }}
-          {{- if .Values.webdav.readinessProbe }}
+          {{- if .Values.webdav.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webdav.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /

--- a/mailu/templates/webmail/deployment.yaml
+++ b/mailu/templates/webmail/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             exec:
               command: [ "curl", "-f", "-L", "-H", "User-Agent: health", "http://localhost/ping" ]
           {{- end }}
-          {{- if .Values.webmail.readinessProbe }}
+          {{- if .Values.webmail.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webmail.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command: [ "curl", "-f", "-L", "-H", "User-Agent: health", "http://localhost/ping" ]


### PR DESCRIPTION
This is the same fix as #250, but for other pods.

Example: the following config does not disable readiness probe for postfix as it should.

```yaml
postfix:
  readinessProbe:
    enabled: false
```