### PR TITLE
feat: Added support for NodePort port numbers configuration

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -297,8 +297,8 @@ Check that the deployed pods are all running.
 | `front.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`            |
 | `front.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`  |
 | `front.hostPort.enabled`                      | Expose front mail ports via hostPort                                                  | `true`          |
-| `front.externalService.enabled`               | Expose front mail ports via external service (ClusterIP or LoadBalancer)              | `false`         |
-| `front.externalService.type`                  | Service type (ClusterIP or LoadBalancer)                                              | `ClusterIP`     |
+| `front.externalService.enabled`               | Expose front mail ports via external service (ClusterIP, NodePort, or LoadBalancer)   | `false`         |
+| `front.externalService.type`                  | Service type (ClusterIP, NodePort, or LoadBalancer)                                   | `ClusterIP`     |
 | `front.externalService.externalTrafficPolicy` | Service externalTrafficPolicy (Cluster or Local)                                      | `Local`         |
 | `front.externalService.loadBalancerIP`        | Service loadBalancerIP                                                                | `""`            |
 | `front.externalService.annotations`           | Service annotations                                                                   | `{}`            |
@@ -309,6 +309,13 @@ Check that the deployed pods are all running.
 | `front.externalService.ports.smtp`            | Expose SMTP port                                                                      | `true`          |
 | `front.externalService.ports.smtps`           | Expose SMTP port (TLS)                                                                | `true`          |
 | `front.externalService.ports.submission`      | Expose Submission port                                                                | `true`          |
+| `front.externalService.nodePorts.pop3`        | POP3 node port (only if `front.externalService.type=NodePort`)                        | `30110`         |
+| `front.externalService.nodePorts.pop3s`       | POP3 (TLS) node port (only if `front.externalService.type=NodePort`)                  | `30995`         |
+| `front.externalService.nodePorts.imap`        | IMAP node port (only if `front.externalService.type=NodePort`)                        | `30143`         |
+| `front.externalService.nodePorts.imaps`       | IMAP (TLS) node port (only if `front.externalService.type=NodePort`)                  | `30993`         |
+| `front.externalService.nodePorts.smtp`        | SMTP node port (only if `front.externalService.type=NodePort`)                        | `30025`         |
+| `front.externalService.nodePorts.smtps`       | SMTP (TLS) node port (only if `front.externalService.type=NodePort`)                  | `30465`         |
+| `front.externalService.nodePorts.submission`  | Submission node port (only if `front.externalService.type=NodePort`)                  | `30587`         |
 | `front.kind`                                  | Kind of resource to create for the front (`Deployment` or `DaemonSet`)                | `Deployment`    |
 | `front.replicaCount`                          | Number of front replicas to deploy (only for `Deployment` kind)                       | `1`             |
 | `front.resources.limits`                      | The resources limits for the container                                                | `{}`            |

--- a/mailu/templates/front/service-external.yaml
+++ b/mailu/templates/front/service-external.yaml
@@ -28,7 +28,7 @@ spec:
       port: 110
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 110
+      nodePort: {{ .nodePorts.pop3 }}
       {{- end }}
     {{- end }}
     {{- if .ports.pop3s }}
@@ -36,7 +36,7 @@ spec:
       port: 995
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 995
+      nodePort: {{ .nodePorts.pop3s }}
       {{- end }}
     {{- end }}
     {{- if .ports.imap }}
@@ -44,7 +44,7 @@ spec:
       port: 143
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 143
+      nodePort: {{ .nodePorts.imap }}
       {{- end }}
     {{- end }}
     {{- if .ports.imaps }}
@@ -52,7 +52,7 @@ spec:
       port: 993
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 993
+      nodePort: {{ .nodePorts.imaps }}
       {{- end }}
     {{- end }}
     {{- if .ports.smtp }}
@@ -60,7 +60,7 @@ spec:
       port: 25
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 25
+      nodePort: {{ .nodePorts.smtp }}
       {{- end }}
     {{- end }}
     {{- if .ports.smtps }}
@@ -68,7 +68,7 @@ spec:
       port: 465
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 465
+      nodePort: {{ .nodePorts.smtps }}
       {{- end }}
     {{- end }}
     {{- if .ports.submission }}
@@ -76,7 +76,7 @@ spec:
       port: 587
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 587
+      nodePort: {{ .nodePorts.smtpd }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -639,9 +639,9 @@ front:
   hostPort:
     enabled: true
 
-  ## Expose front mail ports via external service (ClusterIP or LoadBalancer)
-  ## @param front.externalService.enabled Expose front mail ports via external service (ClusterIP or LoadBalancer)
-  ## @param front.externalService.type Service type (ClusterIP or LoadBalancer)
+  ## Expose front mail ports via external service (ClusterIP, NodePort, or LoadBalancer)
+  ## @param front.externalService.enabled Expose front mail ports via external service (ClusterIP, NodePort, or LoadBalancer)
+  ## @param front.externalService.type Service type (ClusterIP, NodePort, or LoadBalancer)
   ## @param front.externalService.externalTrafficPolicy Service externalTrafficPolicy (Cluster or Local)
   ## @param front.externalService.loadBalancerIP Service loadBalancerIP
   ## @param front.externalService.annotations Service annotations
@@ -652,6 +652,13 @@ front:
   ## @param front.externalService.ports.smtp Expose SMTP port
   ## @param front.externalService.ports.smtps Expose SMTP port (TLS)
   ## @param front.externalService.ports.submission Expose Submission port
+  ## @param front.externalService.nodePorts.pop3 POP3 node port (only if `front.externalService.type=NodePort`)
+  ## @param front.externalService.nodePorts.pop3s POP3 (TLS) node port (only if `front.externalService.type=NodePort`)
+  ## @param front.externalService.nodePorts.imap IMAP node port (only if `front.externalService.type=NodePort`)
+  ## @param front.externalService.nodePorts.imaps IMAP (TLS) node port (only if `front.externalService.type=NodePort`)
+  ## @param front.externalService.nodePorts.smtp SMTP node port (only if `front.externalService.type=NodePort`)
+  ## @param front.externalService.nodePorts.smtps SMTP (TLS) node port (only if `front.externalService.type=NodePort`)
+  ## @param front.externalService.nodePorts.submission Submission node port (only if `front.externalService.type=NodePort`)
   externalService:
     enabled: false
     type: ClusterIP
@@ -668,6 +675,14 @@ front:
       smtp: true
       smtps: true
       submission: true
+    nodePorts:
+      pop3: 30110
+      pop3s: 30995
+      imap: 30143
+      imaps: 30993
+      smtp: 30025
+      smtps: 30465
+      submission: 30587
 
   ## @param front.kind Kind of resource to create for the front (`Deployment` or `DaemonSet`)
   kind: Deployment


### PR DESCRIPTION
Fixes #28 
Relates to fastlorenzo/helm-charts-1#25

This PR:
- adds the ability to customize the nodePort of each mail service when `front.externalService.type=NodePort`
- changes the default nodePort numbers to values within the default range 30000-32767

As I commented on https://github.com/Mailu/helm-charts/issues/268#issuecomment-1676249545, using NodePort numbers < 1024 requires configuring the cluster in a way that is not allowed by many providers.

I think that admins that want to expose mail services on the default port directly on their Kubernetes nodes should use `front.hostPort.enabled=true` instead. [NodePort services](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport) should be preferred when using an external load balancer.

My personal Mailu instance is a "2 nodes cluster + NodePort service + haproxy"  setup (for now, I have disabled `externalService` in Helm and added my own `Service`  resource). It took me some digging to configure all of this properly. I started reorganizing my personal notes into a piece of documentation : https://github.com/bidord/mailu-helm-charts/blob/feat-add-documentation-for-nodeport/mailu/README.md#running-behind-an-external-load-balancer-with-a-nodeport-service Tell me if you are interested in me adding it to this PR.