### PR TITLE
feat: bump mailu version to 2.0.22

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.20
+appVersion: 2.0.22
 version: 1.3.0
 name: mailu
 description: This chart installs the Mailu mail system on kubernetes

--- a/mailu/templates/_helpers.tpl
+++ b/mailu/templates/_helpers.tpl
@@ -82,7 +82,25 @@ Get MailU domain name or throw an error if not set
 {{- end -}}
 
 {{/*
-
+Helper function to get the correct admin port.
+Change was made in Mailu 2.0.22 and the port was switched from 80 to 8080.
+This is for retro-compatibility purposes.
+We need to perform some error handling in case the version provided is not a valid semver.
+Only "master" is allowed to be used as a version other than the semver notation.
+*/}}
+{{- define "mailu.admin.port" -}}
+{{- $semverRegex := `^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?(?:\+[\da-zA-Z-]+(?:\.[\da-zA-Z-]+)*)?$` -}}
+{{- $version := (default (include "mailu.version" .) .Values.admin.image.tag) -}}
+{{- if mustRegexMatch $semverRegex $version -}}
+    {{- if semverCompare "<2.0.22" $version -}}
+        {{- print "80" -}}
+    {{- else -}}
+        {{- print "8080" -}}
+    {{- end -}}
+{{- else -}}
+    {{- print "8080" -}}
+{{- end -}}
+{{- end -}}
 
 {{/* Check for deprecated values and raise an error if found (upgrade to v1.0.0) */}}
 {{- define "mailu.validateValues.deprecated" -}}

--- a/mailu/templates/admin/deployment.yaml
+++ b/mailu/templates/admin/deployment.yaml
@@ -102,7 +102,7 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ int (include "mailu.admin.port" .) }}
               protocol: TCP
           {{- if .Values.admin.resources }}
           resources: {{- toYaml .Values.admin.resources | nindent 12 }}

--- a/mailu/templates/admin/service.yaml
+++ b/mailu/templates/admin/service.yaml
@@ -16,6 +16,6 @@ spec:
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: admin
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
+    - name: http
+      port: {{ int (include "mailu.admin.port" .) }}
+      protocol: TCP


### PR DESCRIPTION
Release notes: https://github.com/Mailu/Mailu/releases/tag/2.0.22

Update is retro-compatible with versions <2.0.22 (the admin container port will then be kept to port `80` instead of the new `8080`).

When setting `mailuVersion` or `admin.image.tag` to a non-valid semver, the chart will behave as if the version is >= 2.0.22 and use the port `8080` for the admin container.