### PR TITLE
Improve healtchecks

### DIFF
--- a/mailu/templates/fetchmail/deployment.yaml
+++ b/mailu/templates/fetchmail/deployment.yaml
@@ -116,7 +116,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'ps ax | grep [/]fetchmail.py'
+                - 'ps ax | grep [/]fetchmail.py && df'
           {{- end }}
           {{- if .Values.fetchmail.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.fetchmail.livenessProbe "enabled") "context" $) | nindent 12 }}
@@ -124,7 +124,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'ps ax | grep [/]fetchmail.py'
+                - 'ps ax | grep [/]fetchmail.py && df'
           {{- end }}
           {{- if .Values.fetchmail.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.fetchmail.readinessProbe "enabled") "context" $) | nindent 12 }}
@@ -132,7 +132,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'ps ax | grep [/]fetchmail.py'
+                - 'ps ax | grep [/]fetchmail.py && df'
           {{- end }}
       volumes:
         - name: data

--- a/mailu/templates/oletools/deployment.yaml
+++ b/mailu/templates/oletools/deployment.yaml
@@ -106,7 +106,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'echo PING|nc -q1 localhost 11343|grep PONG'
+                - 'echo PING|nc -q1 localhost 11343|grep PONG && df'
           {{- end }}
           {{- if .Values.oletools.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.oletools.livenessProbe "enabled") "context" $) | nindent 12 }}
@@ -114,7 +114,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'echo PING|nc -q1 localhost 11343|grep PONG'
+                - 'echo PING|nc -q1 localhost 11343|grep PONG && df'
           {{- end }}
           {{- if .Values.oletools.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.oletools.readinessProbe "enabled") "context" $) | nindent 12 }}
@@ -122,7 +122,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'echo PING|nc -q1 localhost 11343|grep PONG'
+                - 'echo PING|nc -q1 localhost 11343|grep PONG && df'
           {{- end }}
       {{- if .Values.oletools.extraVolumes }}
       volumes:

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -121,7 +121,7 @@ spec:
               command:
                 - sh
                 - -c
-                - '! /usr/libexec/postfix/master -t'
+                - '! /usr/libexec/postfix/master -t && df'
           {{- end }}
           {{- if .Values.postfix.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.postfix.livenessProbe "enabled") "context" $) | nindent 12 }}
@@ -129,7 +129,7 @@ spec:
               command:
                 - sh
                 - -c
-                - '! /usr/libexec/postfix/master -t'
+                - '! /usr/libexec/postfix/master -t && df'
           {{- end }}
           {{- if .Values.postfix.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.postfix.readinessProbe "enabled") "context" $) | nindent 12 }}
@@ -137,7 +137,7 @@ spec:
               command:
                 - sh
                 - -c
-                - '! /usr/libexec/postfix/master -t'
+                - '! /usr/libexec/postfix/master -t && df'
           {{- end }}
       volumes:
         - name: data

--- a/mailu/templates/rspamd/deployment.yaml
+++ b/mailu/templates/rspamd/deployment.yaml
@@ -115,21 +115,27 @@ spec:
           {{- end }}
           {{- if .Values.rspamd.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.rspamd.startupProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
-              port: rspamd-http
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl --fail http://localhost:11334/ 2>&1 | grep "Rspamd" && df'
           {{- end }}
           {{- if .Values.rspamd.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.rspamd.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
-              port: rspamd-http
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl --fail http://localhost:11334/ 2>&1 | grep "Rspamd" && df'
           {{- end }}
           {{- if .Values.rspamd.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.rspamd.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /
-              port: rspamd-http
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'curl --fail http://localhost:11334/ 2>&1 | grep "Rspamd" && df'
           {{- end }}
       volumes:
         - name: data

--- a/mailu/templates/webdav/deployment.yaml
+++ b/mailu/templates/webdav/deployment.yaml
@@ -109,7 +109,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'ps ax | grep [/]radicale.conf'
+                - 'ps ax | grep [/]radicale.conf && df'
           {{- end }}
           {{- if .Values.webdav.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webdav.livenessProbe "enabled") "context" $) | nindent 12 }}
@@ -117,7 +117,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'ps ax | grep [/]radicale.conf'
+                - 'ps ax | grep [/]radicale.conf && df'
           {{- end }}
           {{- if .Values.webdav.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webdav.readinessProbe "enabled") "context" $) | nindent 12 }}
@@ -125,7 +125,7 @@ spec:
               command:
                 - sh
                 - -c
-                - 'ps ax | grep [/]radicale.conf'
+                - 'ps ax | grep [/]radicale.conf && df'
           {{- end }}
       volumes:
         - name: data

--- a/mailu/templates/webmail/deployment.yaml
+++ b/mailu/templates/webmail/deployment.yaml
@@ -107,34 +107,25 @@ spec:
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webmail.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - curl
-                - -f
-                - -L
-                - -H
-                - 'User-Agent: health'
-                - "http://localhost/ping"
+                - sh
+                - -c
+                - 'curl -f -L -H "User-Agent: health" http://localhost/ping && df'
           {{- end }}
           {{- if .Values.webmail.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webmail.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - curl
-                - -f
-                - -L
-                - -H
-                - 'User-Agent: health'
-                - "http://localhost/ping"
+                - sh
+                - -c
+                - 'curl -f -L -H "User-Agent: health" http://localhost/ping && df'
           {{- end }}
           {{- if .Values.webmail.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.webmail.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
-                - curl
-                - -f
-                - -L
-                - -H
-                - 'User-Agent: health'
-                - "http://localhost/ping"
+                - sh
+                - -c
+                - 'curl -f -L -H "User-Agent: health" http://localhost/ping && df'
           {{- end }}
       volumes:
         - name: data


### PR DESCRIPTION
Currently the most of the health check only check if the daemon itself is running, but not if it is actually functioning correctly.

For the most services this is not so easy, but what you can say for sure is, that the services need to have storage correctly mounted and it needs to be writeable.

If you are using mailu in a distributed environment with distributed storage (like in my case nfs), it can happen that storage is not available. In this case the readiness check should reflect this, because creation of a new pod could auto heal this problem in some cases. In any way, without writable storage the service is not available anyways.