### PR TITLE
Add replicaCount for admin, dovecot, webmail and oletools

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -359,13 +359,14 @@ Check that the deployed pods are all running.
 ### Admin parameters
 
 | Name                                          | Description                                                                           | Value               |
-| --------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| --------------------------------------------- |---------------------------------------------------------------------------------------| ------------------- |
 | `admin.enabled`                               | Enable access to the admin interface                                                  | `true`              |
 | `admin.uri`                                   | URI to access the admin interface                                                     | `/admin`            |
 | `admin.logLevel`                              | Override default log level                                                            | `""`                |
 | `admin.image.repository`                      | Pod image repository                                                                  | `mailu/admin`       |
 | `admin.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `admin.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `admin.replicaCount`                          | Number of admin replicas to deploy                                                    | `1`                                                                               |
 | `admin.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `admin.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `admin.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -502,6 +503,7 @@ Check that the deployed pods are all running.
 | `dovecot.image.repository`                      | Pod image repository                                                                  | `mailu/dovecot`     |
 | `dovecot.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `dovecot.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `dovecot.replicaCount`                          | Number of dovecot replicas to deploy                                                  | `1`                                                                               |
 | `dovecot.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `dovecot.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `dovecot.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -680,7 +682,7 @@ Check that the deployed pods are all running.
 ### webmail parameters
 
 | Name                                            | Description                                                                           | Value                                                                             |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| ----------------------------------------------- |---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
 | `webmail.enabled`                               | Enable deployment of Roundcube webmail                                                | `true`                                                                            |
 | `webmail.uri`                                   | URI to access Roundcube webmail                                                       | `/webmail`                                                                        |
 | `webmail.type`                                  | Type of webmail to deploy (`roundcube` or `snappymail`)                               | `roundcube`                                                                       |
@@ -689,6 +691,7 @@ Check that the deployed pods are all running.
 | `webmail.image.repository`                      | Pod image repository                                                                  | `mailu/webmail`                                                                   |
 | `webmail.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                                                                              |
 | `webmail.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`                                                                    |
+| `webmail.replicaCount`                          | Number of webmail replicas to deploy                                                  | `1`                                                                               |
 | `webmail.persistence.size`                      | Pod pvc size                                                                          | `20Gi`                                                                            |
 | `webmail.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                                                                              |
 | `webmail.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]`                                                               |
@@ -861,12 +864,13 @@ Check that the deployed pods are all running.
 ### OLETools parameters
 
 | Name                                             | Description                                                                           | Value            |
-| ------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------------- |
+| ------------------------------------------------ |---------------------------------------------------------------------------------------| ---------------- |
 | `oletools.enabled`                               | Enable OLETools                                                                       | `true`           |
 | `oletools.logLevel`                              | Override default log level                                                            | `""`             |
 | `oletools.image.repository`                      | Pod image repository                                                                  | `mailu/oletools` |
 | `oletools.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`             |
 | `oletools.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`   |
+| `oletools.replicaCount`                          | Number of oletools replicas to deploy                                                 | `1`                                                                               |
 | `oletools.resources.limits`                      | The resources limits for the container                                                | `{}`             |
 | `oletools.resources.requests`                    | The requested resources for the container                                             | `{}`             |
 | `oletools.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`           |

--- a/mailu/templates/admin/deployment.yaml
+++ b/mailu/templates/admin/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.admin.replicaCount }}
   {{- if .Values.admin.updateStrategy }}
   strategy: {{- toYaml .Values.admin.updateStrategy | nindent 4 }}
   {{- end }}

--- a/mailu/templates/dovecot/deployment.yaml
+++ b/mailu/templates/dovecot/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.dovecot.replicaCount }}
   {{- if .Values.dovecot.updateStrategy }}
   strategy: {{- toYaml .Values.dovecot.updateStrategy | nindent 4 }}
   {{- end }}

--- a/mailu/templates/oletools/deployment.yaml
+++ b/mailu/templates/oletools/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.oletools.replicaCount }}
   {{- if .Values.oletools.updateStrategy }}
   strategy: {{- toYaml .Values.oletools.updateStrategy | nindent 4 }}
   {{- end }}

--- a/mailu/templates/webmail/deployment.yaml
+++ b/mailu/templates/webmail/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.webmail.replicaCount }}
   {{- if .Values.webmail.updateStrategy }}
   strategy: {{- toYaml .Values.webmail.updateStrategy | nindent 4 }}
   {{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -864,6 +864,9 @@ admin:
     tag: ""
     pullPolicy: IfNotPresent
 
+  ## @param admin.replicaCount Number of admin replicas to deploy
+  replicaCount: 1
+
   ## Pod persistence (if not using single_pvc)
   ## @param admin.persistence.size Pod pvc size
   ## @param admin.persistence.storageClass Pod pvc storage class
@@ -1304,6 +1307,9 @@ dovecot:
     repository: mailu/dovecot
     tag: ""
     pullPolicy: IfNotPresent
+
+  ## @param dovecot.replicaCount Number of dovecot replicas to deploy
+  replicaCount: 1
 
   ## Pod persistence (if not using single_pvc)
   ## @param dovecot.persistence.size Pod pvc size
@@ -1971,6 +1977,9 @@ webmail:
     tag: ""
     pullPolicy: IfNotPresent
 
+  ## @param webmail.replicaCount Number of webmail replicas to deploy
+  replicaCount: 1
+
   ## Pod persistence (if not using single_pvc)
   ## @param webmail.persistence.size Pod pvc size
   ## @param webmail.persistence.storageClass Pod pvc storage class
@@ -2564,6 +2573,9 @@ oletools:
     repository: mailu/oletools
     tag: ""
     pullPolicy: IfNotPresent
+
+  ## @param oletools.replicaCount Number of oletools replicas to deploy
+  replicaCount: 1
 
   ## Pod resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
In general those services can easily deployed with multiple replicas without any issues. So why not be able to configure them?