### PR TITLE
Add persistence flag for all services

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -359,13 +359,14 @@ Check that the deployed pods are all running.
 ### Admin parameters
 
 | Name                                          | Description                                                                           | Value               |
-| --------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+|-----------------------------------------------| ------------------------------------------------------------------------------------- | ------------------- |
 | `admin.enabled`                               | Enable access to the admin interface                                                  | `true`              |
 | `admin.uri`                                   | URI to access the admin interface                                                     | `/admin`            |
 | `admin.logLevel`                              | Override default log level                                                            | `""`                |
 | `admin.image.repository`                      | Pod image repository                                                                  | `mailu/admin`       |
 | `admin.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `admin.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `admin.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `admin.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `admin.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `admin.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -437,11 +438,12 @@ Check that the deployed pods are all running.
 ### Postfix parameters
 
 | Name                                            | Description                                                                           | Value               |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+|-------------------------------------------------| ------------------------------------------------------------------------------------- | ------------------- |
 | `postfix.logLevel`                              | Override default log level                                                            | `""`                |
 | `postfix.image.repository`                      | Pod image repository                                                                  | `mailu/postfix`     |
 | `postfix.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `postfix.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `postfix.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `postfix.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `postfix.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `postfix.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -496,12 +498,13 @@ Check that the deployed pods are all running.
 ### Dovecot parameters
 
 | Name                                            | Description                                                                           | Value               |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+|-------------------------------------------------| ------------------------------------------------------------------------------------- | ------------------- |
 | `dovecot.enabled`                               | Enable dovecot                                                                        | `true`              |
 | `dovecot.logLevel`                              | Override default log level                                                            | `""`                |
 | `dovecot.image.repository`                      | Pod image repository                                                                  | `mailu/dovecot`     |
 | `dovecot.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `dovecot.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `dovecot.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `dovecot.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `dovecot.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `dovecot.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -558,13 +561,14 @@ Check that the deployed pods are all running.
 ### rspamd parameters
 
 | Name                                           | Description                                                                           | Value               |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+|------------------------------------------------| ------------------------------------------------------------------------------------- | ------------------- |
 | `rspamd.overrides`                             | Enable rspamd overrides                                                               | `{}`                |
 | `rspamd.antivirusAction`                       | Action to take when an virus is detected. Possible values: `reject` or `discard`      | `discard`           |
 | `rspamd.logLevel`                              | Override default log level                                                            | `""`                |
 | `rspamd.image.repository`                      | Pod image repository                                                                  | `mailu/rspamd`      |
 | `rspamd.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `rspamd.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `rspamd.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `rspamd.persistence.size`                      | Pod pvc size                                                                          | `1Gi`               |
 | `rspamd.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `rspamd.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -680,7 +684,7 @@ Check that the deployed pods are all running.
 ### webmail parameters
 
 | Name                                            | Description                                                                           | Value                                                                             |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------- |-----------------------------------------------------------------------------------|
 | `webmail.enabled`                               | Enable deployment of Roundcube webmail                                                | `true`                                                                            |
 | `webmail.uri`                                   | URI to access Roundcube webmail                                                       | `/webmail`                                                                        |
 | `webmail.type`                                  | Type of webmail to deploy (`roundcube` or `snappymail`)                               | `roundcube`                                                                       |
@@ -689,7 +693,7 @@ Check that the deployed pods are all running.
 | `webmail.image.repository`                      | Pod image repository                                                                  | `mailu/webmail`                                                                   |
 | `webmail.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                                                                              |
 | `webmail.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`                                                                    |
-| `webmail.persistence.size`                      | Pod pvc size                                                                          | `20Gi`                                                                            |
+| `webmail.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `webmail.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                                                                              |
 | `webmail.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]`                                                               |
 | `webmail.persistence.claimNameOverride`         | Pod pvc name override                                                                 | `""`                                                                              |
@@ -742,12 +746,13 @@ Check that the deployed pods are all running.
 ### webdav parameters
 
 | Name                                           | Description                                                                           | Value               |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+|------------------------------------------------| ------------------------------------------------------------------------------------- | ------------------- |
 | `webdav.enabled`                               | Enable deployment of WebDAV server (using Radicale)                                   | `false`             |
 | `webdav.logLevel`                              | Override default log level                                                            | `""`                |
 | `webdav.image.repository`                      | Pod image repository                                                                  | `mailu/radicale`    |
 | `webdav.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `webdav.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `webdav.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `webdav.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `webdav.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `webdav.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |
@@ -801,13 +806,14 @@ Check that the deployed pods are all running.
 ### fetchmail parameters
 
 | Name                                              | Description                                                                           | Value               |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+|---------------------------------------------------| ------------------------------------------------------------------------------------- |---------------------|
 | `fetchmail.enabled`                               | Enable deployment of fetchmail                                                        | `false`             |
 | `fetchmail.delay`                                 | Delay between fetchmail runs                                                          | `600`               |
 | `fetchmail.logLevel`                              | Override default log level                                                            | `""`                |
 | `fetchmail.image.repository`                      | Pod image repository                                                                  | `mailu/fetchmail`   |
 | `fetchmail.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `""`                |
 | `fetchmail.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`      |
+| `fetchmail.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                                                                            |
 | `fetchmail.persistence.size`                      | Pod pvc size                                                                          | `20Gi`              |
 | `fetchmail.persistence.storageClass`              | Pod pvc storage class                                                                 | `""`                |
 | `fetchmail.persistence.accessModes`               | Pod pvc access modes                                                                  | `["ReadWriteOnce"]` |

--- a/mailu/templates/admin/deployment.yaml
+++ b/mailu/templates/admin/deployment.yaml
@@ -130,9 +130,14 @@ spec:
               add:
                 - NET_BIND_SERVICE
       volumes:
+{{- if not .Values.admin.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.admin.claimName" . }}
+{{- end }}
         {{- if .Values.admin.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.admin.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/mailu/templates/admin/pvc.yaml
+++ b/mailu/templates/admin/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if not .Values.persistence.single_pvc }}
+{{- if and (.Values.admin.persistence.enabled) (not .Values.persistence.single_pvc) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/templates/dovecot/deployment.yaml
+++ b/mailu/templates/dovecot/deployment.yaml
@@ -147,9 +147,14 @@ spec:
                 - 'kill -0 `cat /run/dovecot/master.pid`'
           {{- end }}
       volumes:
+{{- if not .Values.dovecot.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.dovecot.claimName" . }}
+{{- end }}
         {{- if .Values.dovecot.overrides }}
         - name: overrides
           configMap:

--- a/mailu/templates/dovecot/pvc.yaml
+++ b/mailu/templates/dovecot/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.dovecot.enabled }}
+{{- if and (.Values.dovecot.enabled) (.Values.dovecot.persistence.enabled) }}
 {{- if not .Values.persistence.single_pvc }}
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/mailu/templates/fetchmail/deployment.yaml
+++ b/mailu/templates/fetchmail/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if .Values.fetchmail.enabled }}
+{{- if (.Values.fetchmail.enabled) }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -135,9 +135,14 @@ spec:
                 - 'ps ax | grep [/]fetchmail.py'
           {{- end }}
       volumes:
+{{- if not .Values.fetchmail.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.fetchmail.claimName" . }}
+{{- end }}
         {{- if .Values.fetchmail.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.fetchmail.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/mailu/templates/fetchmail/pvc.yaml
+++ b/mailu/templates/fetchmail/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if and (.Values.fetchmail.enabled) (not .Values.persistence.single_pvc) }}
+{{- if and (.Values.fetchmail.enabled) (.Values.fetchmail.persistence.enabled) (not .Values.persistence.single_pvc) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/templates/postfix/deployment.yaml
+++ b/mailu/templates/postfix/deployment.yaml
@@ -140,9 +140,14 @@ spec:
                 - '! /usr/libexec/postfix/master -t'
           {{- end }}
       volumes:
+{{- if not .Values.postfix.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.postfix.claimName" . }}
+{{- end }}
         {{- if .Values.postfix.overrides }}
         - name: overrides
           configMap:

--- a/mailu/templates/postfix/pvc.yaml
+++ b/mailu/templates/postfix/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if not .Values.persistence.single_pvc }}
+{{- if and (.Values.postfix.persistence.enabled) (not .Values.persistence.single_pvc) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/templates/rspamd/deployment.yaml
+++ b/mailu/templates/rspamd/deployment.yaml
@@ -132,9 +132,14 @@ spec:
               port: rspamd-http
           {{- end }}
       volumes:
+{{- if not .Values.rspamd.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.rspamd.claimName" . }}
+{{- end }}
         {{- if .Values.rspamd.overrides }}
         - name: overrides
           configMap:

--- a/mailu/templates/rspamd/pvc.yaml
+++ b/mailu/templates/rspamd/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if not .Values.persistence.single_pvc }}
+{{- if and (.Values.rspamd.persistence.enabled) (not .Values.persistence.single_pvc) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/templates/webdav/deployment.yaml
+++ b/mailu/templates/webdav/deployment.yaml
@@ -128,9 +128,14 @@ spec:
                 - 'ps ax | grep [/]radicale.conf'
           {{- end }}
       volumes:
+{{- if not .Values.webmail.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.webdav.claimName" . }}
+{{- end }}
         {{- if .Values.webdav.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.webdav.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/mailu/templates/webdav/pvc.yaml
+++ b/mailu/templates/webdav/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if and (.Values.webdav.enabled) (not .Values.persistence.single_pvc) }}
+{{- if and (.Values.webdav.enabled) (.Values.webdav.persistence.enabled) (not .Values.persistence.single_pvc) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/templates/webmail/deployment.yaml
+++ b/mailu/templates/webmail/deployment.yaml
@@ -137,9 +137,14 @@ spec:
                 - "http://localhost/ping"
           {{- end }}
       volumes:
+{{- if not .Values.webmail.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ include "mailu.webmail.claimName" . }}
+{{- end }}
         {{- if .Values.webmail.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.webmail.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/mailu/templates/webmail/pvc.yaml
+++ b/mailu/templates/webmail/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if and (.Values.webmail.enabled) (not .Values.persistence.single_pvc) }}
+{{- if and (.Values.webmail.enabled) (.Values.webmail.persistence.enabled) (not .Values.persistence.single_pvc) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -865,12 +865,14 @@ admin:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param admin.persistence.enabled Enable persistence using PVC
   ## @param admin.persistence.size Pod pvc size
   ## @param admin.persistence.storageClass Pod pvc storage class
   ## @param admin.persistence.accessModes Pod pvc access modes
   ## @param admin.persistence.claimNameOverride Pod pvc name override
   ## @param admin.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 20Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]
@@ -1101,12 +1103,14 @@ postfix:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param postfix.persistence.enabled Enable persistence using PVC
   ## @param postfix.persistence.size Pod pvc size
   ## @param postfix.persistence.storageClass Pod pvc storage class
   ## @param postfix.persistence.accessModes Pod pvc access modes
   ## @param postfix.persistence.claimNameOverride Pod pvc name override
   ## @param postfix.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 20Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]
@@ -1306,12 +1310,14 @@ dovecot:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param dovecot.persistence.enabled Enable persistence using PVC
   ## @param dovecot.persistence.size Pod pvc size
   ## @param dovecot.persistence.storageClass Pod pvc storage class
   ## @param dovecot.persistence.accessModes Pod pvc access modes
   ## @param dovecot.persistence.claimNameOverride Pod pvc name override
   ## @param dovecot.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 20Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]
@@ -1531,12 +1537,14 @@ rspamd:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param rspamd.persistence.enabled Enable persistence using PVC
   ## @param rspamd.persistence.size Pod pvc size
   ## @param rspamd.persistence.storageClass Pod pvc storage class
   ## @param rspamd.persistence.accessModes Pod pvc access modes
   ## @param rspamd.persistence.claimNameOverride Pod pvc name override
   ## @param rspamd.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 1Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]
@@ -1972,12 +1980,14 @@ webmail:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param webmail.persistence.enabled Enable persistence using PVC
   ## @param webmail.persistence.size Pod pvc size
   ## @param webmail.persistence.storageClass Pod pvc storage class
   ## @param webmail.persistence.accessModes Pod pvc access modes
   ## @param webmail.persistence.claimNameOverride Pod pvc name override
   ## @param webmail.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 20Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]
@@ -2169,12 +2179,14 @@ webdav:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param webdav.persistence.enabled Enable persistence using PVC
   ## @param webdav.persistence.size Pod pvc size
   ## @param webdav.persistence.storageClass Pod pvc storage class
   ## @param webdav.persistence.accessModes Pod pvc access modes
   ## @param webdav.persistence.claimNameOverride Pod pvc name override
   ## @param webdav.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 20Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]
@@ -2369,12 +2381,14 @@ fetchmail:
     pullPolicy: IfNotPresent
 
   ## Pod persistence (if not using single_pvc)
+  ## @param fetchmail.persistence.enabled Enable persistence using PVC
   ## @param fetchmail.persistence.size Pod pvc size
   ## @param fetchmail.persistence.storageClass Pod pvc storage class
   ## @param fetchmail.persistence.accessModes Pod pvc access modes
   ## @param fetchmail.persistence.claimNameOverride Pod pvc name override
   ## @param fetchmail.persistence.annotations Pod pvc annotations
   persistence:
+    enabled: true
     size: 20Gi
     storageClass: ""
     accessModes: [ReadWriteOnce]


### PR DESCRIPTION
For testing environments it is very useful to disable persistence. Also some of the service only require persistence if you use specific features, and otherwise can simplify deployment if you are able to disable it for certain services.