### PR TITLE
Fix rspamd.overrides configmap

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -563,6 +563,7 @@ Check that the deployed pods are all running.
 
 | Name                                           | Description                                                                           | Value               |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `rspamd.enabled`                               | Enable rspamd                                                                         | `true`              |
 | `rspamd.overrides`                             | Enable rspamd overrides                                                               | `{}`                |
 | `rspamd.antivirusAction`                       | Action to take when an virus is detected. Possible values: `reject` or `discard`      | `discard`           |
 | `rspamd.logLevel`                              | Override default log level                                                            | `""`                |

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1519,7 +1519,7 @@ dovecot:
 rspamd:
   ## @param rspamd.enabled Enable rspamd
   enabled: true
-  
+
   ## @param rspamd.overrides Enable rspamd overrides
   ## More info here: https://mailu.io/master/faq.html#how-can-i-override-settings
   ## Example:

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1517,6 +1517,9 @@ dovecot:
 
 ## @section rspamd parameters
 rspamd:
+  ## @param rspamd.enabled Enable rspamd
+  enabled: true
+  
   ## @param rspamd.overrides Enable rspamd overrides
   ## More info here: https://mailu.io/master/faq.html#how-can-i-override-settings
   ## Example:


### PR DESCRIPTION
I wanted to enable `rspamd.overrides`, but when installing that through helm the rspamd pod would deploy with an error:
```
  Warning  FailedMount  23s (x7 over 55s)  kubelet            MountVolume.SetUp failed for volume "overrides" : configmap "mailu-rspamd-override" not found
```

To fix this I had to patch in the proposed change because of how https://github.com/Mailu/helm-charts/blob/master/mailu/templates/rspamd/configmap.yaml#L1 is written.