### PR TITLE
added flag to enable rspamd

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.0.30
+appVersion: 2024.06.3
 version: 1.5.0
 name: mailu
 description: This chart installs the Mailu mail system on kubernetes

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -563,6 +563,7 @@ Check that the deployed pods are all running.
 
 | Name                                           | Description                                                                           | Value               |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| `rspamd.enabled`                               | Enable rspamd                                                                         | `true`              |
 | `rspamd.overrides`                             | Enable rspamd overrides                                                               | `{}`                |
 | `rspamd.antivirusAction`                       | Action to take when an virus is detected. Possible values: `reject` or `discard`      | `discard`           |
 | `rspamd.logLevel`                              | Override default log level                                                            | `""`                |

--- a/mailu/templates/rspamd/deployment.yaml
+++ b/mailu/templates/rspamd/deployment.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.rspamd.enabled }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -146,3 +147,4 @@ spec:
         {{- if .Values.rspamd.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.rspamd.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+{{ end }}

--- a/mailu/templates/rspamd/pvc.yaml
+++ b/mailu/templates/rspamd/pvc.yaml
@@ -1,5 +1,5 @@
 ---
-{{- if not .Values.persistence.single_pvc }}
+{{- if and (not .Values.persistence.single_pvc) .Values.rspamd.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/mailu/templates/rspamd/service.yaml
+++ b/mailu/templates/rspamd/service.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.rspamd.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -22,3 +23,4 @@ spec:
     - name: rspamd-http
       protocol: TCP
       port: 11334
+{{ end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1517,7 +1517,7 @@ dovecot:
 
 ## @section rspamd parameters
 rspamd:
-  ## @param admin.enabled Enable rspamd 
+  ## @param rspamd.enabled Enable rspamd
   enabled: true
   ## @param rspamd.overrides Enable rspamd overrides
   ## More info here: https://mailu.io/master/faq.html#how-can-i-override-settings

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1517,6 +1517,8 @@ dovecot:
 
 ## @section rspamd parameters
 rspamd:
+  ## @param admin.enabled Enable rspamd 
+  enabled: true
   ## @param rspamd.overrides Enable rspamd overrides
   ## More info here: https://mailu.io/master/faq.html#how-can-i-override-settings
   ## Example:


### PR DESCRIPTION
this PR adds the enable flag to rspamd, as the value is by default "false" it skips the entire config if not set.
for example, the configmap to override settings was entierly skipped when i tried to upgrade
