### PR TITLE
Ipv6 capabillity for front

### DIFF
--- a/mailu/templates/front/service-external.yaml
+++ b/mailu/templates/front/service-external.yaml
@@ -22,6 +22,7 @@ spec:
   {{- if .loadBalancerIP }}
   loadBalancerIP: {{ .loadBalancerIP }}
   {{- end }}
+  ipFamilyPolicy: {{ .ipFamilyPolicy | default "SingleStack" }}
   ports:
     {{- if .ports.pop3 }}
     - name: pop3

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -659,6 +659,7 @@ front:
     ## type: LoadBalancer
     loadBalancerIP: ""
     externalTrafficPolicy: Local
+    ipFamilyPolicy: PreferDualStack
     annotations: {}
     ports:
       pop3: false

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -659,7 +659,7 @@ front:
     ## type: LoadBalancer
     loadBalancerIP: ""
     externalTrafficPolicy: Local
-    ipFamilyPolicy: PreferDualStack
+    ipFamilyPolicy: SingleStack
     annotations: {}
     ports:
       pop3: false


### PR DESCRIPTION
This change adds IPv6 capabillity to the front pod, and to its nginx. Because it starts to listen on IPv6 also. 