### PR TITLE
fix helmchart notes duplicate 'get secrets'

### DIFF
--- a/mailu/templates/NOTES.txt
+++ b/mailu/templates/NOTES.txt
@@ -19,7 +19,7 @@ You can login to the admin panel using the following initial credentials (if not
         The password can be retrieved in the '{{ include "mailu.initialAccount.secretName" . }}' secret.
         To retrieve the password, run:
 
-          kubectl --namespace={{ .Release.Namespace }} get secrets get secrets {{ include "mailu.initialAccount.secretName" . }} -o jsonpath='{.data.{{ include "mailu.initialAccount.secretKey" . }}}' | base64 --decode
+          kubectl --namespace={{ .Release.Namespace }} get secrets {{ include "mailu.initialAccount.secretName" . }} -o jsonpath='{.data.{{ include "mailu.initialAccount.secretKey" . }}}' | base64 --decode
 
         !!! Please change the password after 1st login !!!
 


### PR DESCRIPTION
Fixed kubectl command to retrieve the initial password.   
'get secrets' was included twice.