### PR TITLE
feat: added Tika support

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -935,6 +935,63 @@ Check that the deployed pods are all running.
 | `oletools.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                    | `[]`             |
 | `oletools.extraContainers`                       | Add additional containers to the pod                                                  | `[]`             |
 
+### Tika parameters
+
+| Name                                         | Description                                                                                     | Value           |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------- |
+| `tika.enabled`                               | Enable OLETools                                                                                 | `true`          |
+| `tika.logLevel`                              | Override default log level                                                                      | `""`            |
+| `tika.languages`                             | Array of languages to enable (sets the FULL_TEXT_SEARCH environment variable); "off" to disable | `["en"]`        |
+| `tika.image.repository`                      | Pod image repository                                                                            | `apache/tika`   |
+| `tika.image.tag`                             | Pod image tag                                                                                   | `2.9.2.1-full`  |
+| `tika.image.pullPolicy`                      | Pod image pull policy                                                                           | `IfNotPresent`  |
+| `tika.image.registry`                        | Pod image registry (specific for tika as it is not part of the mailu organization)              | `docker.io`     |
+| `tika.resources.limits`                      | The resources limits for the container                                                          | `{}`            |
+| `tika.resources.requests`                    | The requested resources for the container                                                       | `{}`            |
+| `tika.livenessProbe.enabled`                 | Enable livenessProbe                                                                            | `true`          |
+| `tika.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                             | `3`             |
+| `tika.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                         | `10`            |
+| `tika.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                | `10`            |
+| `tika.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                             | `1`             |
+| `tika.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                               | `5`             |
+| `tika.readinessProbe.enabled`                | Enable readinessProbe                                                                           | `true`          |
+| `tika.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                        | `10`            |
+| `tika.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                               | `10`            |
+| `tika.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                              | `5`             |
+| `tika.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                            | `3`             |
+| `tika.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                            | `1`             |
+| `tika.startupProbe.enabled`                  | Enable startupProbe                                                                             | `false`         |
+| `tika.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                          | `10`            |
+| `tika.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                 | `10`            |
+| `tika.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                | `5`             |
+| `tika.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                              | `3`             |
+| `tika.startupProbe.successThreshold`         | Success threshold for startupProbe                                                              | `1`             |
+| `tika.podLabels`                             | Add extra labels to pod                                                                         | `{}`            |
+| `tika.podAnnotations`                        | Add extra annotations to the pod                                                                | `{}`            |
+| `tika.nodeSelector`                          | Node labels selector for pod assignment                                                         | `{}`            |
+| `tika.initContainers`                        | Add additional init containers to the pod                                                       | `[]`            |
+| `tika.priorityClassName`                     | Pods' priorityClassName                                                                         | `""`            |
+| `tika.podSecurityContext.enabled`            | Enabled pods' Security Context                                                                  | `false`         |
+| `tika.podSecurityContext.fsGroup`            | Set pods' Security Context fsGroup                                                              | `1001`          |
+| `tika.containerSecurityContext.enabled`      | Enabled containers' Security Context                                                            | `false`         |
+| `tika.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                                      | `1001`          |
+| `tika.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                                   | `false`         |
+| `tika.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                                       | `2`             |
+| `tika.affinity`                              | Affinity for tika pod assignment                                                                | `{}`            |
+| `tika.tolerations`                           | Tolerations for pod assignment                                                                  | `[]`            |
+| `tika.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                            | `3`             |
+| `tika.hostAliases`                           | Pod pod host aliases                                                                            | `[]`            |
+| `tika.schedulerName`                         | Name of the k8s scheduler (other than default)                                                  | `""`            |
+| `tika.service.annotations`                   | tika service annotations                                                                        | `{}`            |
+| `tika.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                  | `[]`            |
+| `tika.updateStrategy.type`                   | Can be set to RollingUpdate or OnDelete                                                         | `RollingUpdate` |
+| `tika.extraEnvVars`                          | Extra environment variable to pass to the running container                                     | `[]`            |
+| `tika.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra environment variables to mount in the pod           | `""`            |
+| `tika.extraEnvVarsSecret`                    | Name of existing Secret containing extra environment variables to mount in the pod              | `""`            |
+| `tika.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the pod                            | `[]`            |
+| `tika.extraVolumes`                          | Optionally specify extra list of additional volumes for the pod(s)                              | `[]`            |
+| `tika.extraContainers`                       | Add additional containers to the pod                                                            | `[]`            |
+
 
 ## Example values.yaml to get started
 

--- a/mailu/ci/helm-lint-values.yaml
+++ b/mailu/ci/helm-lint-values.yaml
@@ -145,3 +145,12 @@ redis:
       limits:
         memory: 500Mi
         cpu: 1
+
+tika:
+  enabled: true
+  languages:
+    - en
+    - fr
+
+oletools:
+  enabled: true

--- a/mailu/templates/_helpers.tpl
+++ b/mailu/templates/_helpers.tpl
@@ -163,6 +163,7 @@ Please read the upgrade guide at XXX.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "mailu.validateValues.deprecated" .) -}}
 {{- $messages := append $messages (include "mailu.validateValues.domain" .) -}}
+{{- $messages := append $messages (include "mailu.validateValues.tika" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 {{- if $message -}}
@@ -176,5 +177,34 @@ Please read the upgrade guide at XXX.
 {{- if not .Values.domain }}
 mailu: domain
     You need to set the domain to be used
+{{- end -}}
+{{- end -}}
+
+{{/* Check if .Values.tika.enabled and .Values.tika.languages is a non-empty array.
+If .Values.tika.enabled is false, then mailu.fullTextSearch should be "off".
+If .Values.tika.enabled is true, and .Values.tika.languages is an empty array, throw an error.
+If .Values.tika.enabled is true, and .Values.tika.languages is a non-empty array, then mailu.fullTextSearch should be all languages joined by a comma.
+*/}}
+{{- define "mailu.validateValues.tika" -}}
+{{- if .Values.tika.enabled -}}
+{{/* Check if .Values.tika.languages is an empty array */}}
+{{- if not .Values.tika.languages -}}
+mailu: tika
+    Tika is enabled but no languages are set (tika.enabled = true, tika.languages = [])
+    You need to set at least one language for Tika in tika.languages
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Check if .Values.tika.enabled is false or a comma-separated list of languages in .Values.tika.languages */}}
+{{- define "mailu.fullTextSearch" -}}
+{{- if .Values.tika.enabled -}}
+    {{- if not .Values.tika.languages -}}
+        {{- print "off" -}}
+    {{- else -}}
+        {{- join "," .Values.tika.languages -}}
+    {{- end -}}
+{{- else -}}
+    {{- print "off" -}}
 {{- end -}}
 {{- end -}}

--- a/mailu/templates/_services.tpl
+++ b/mailu/templates/_services.tpl
@@ -11,6 +11,7 @@ Mailu services:
 - rspamd
 - webdav
 - oletools
+- tika
 
 Service name can be retrieved with `mailu.SERVICE.serviceName`
 Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
@@ -155,6 +156,15 @@ Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
 {{/* Returns oletools internal service fqdn. */}}
 {{- define "mailu.oletools.serviceFqdn" -}}
 {{- printf "%s.%s.svc.%s" (include "mailu.oletools.serviceName" . ) (include "common.names.namespace" . ) (include "mailu.clusterDomain" . ) -}}
+{{- end -}}
+
+{{/* Returns tika internal service name. */}}
+{{- define "mailu.tika.serviceName" -}}
+{{- printf "%s-tika" (include "mailu.fullname" .) -}}
+{{- end -}}
+{{/* Returns tika internal service fqdn. */}}
+{{- define "mailu.tika.serviceFqdn" -}}
+{{- printf "%s.%s.svc.%s" (include "mailu.tika.serviceName" . ) (include "common.names.namespace" . ) (include "mailu.clusterDomain" . ) -}}
 {{- end -}}
 
 

--- a/mailu/templates/envvars-configmap.yaml
+++ b/mailu/templates/envvars-configmap.yaml
@@ -47,7 +47,6 @@ data:
   DOMAIN: {{ .Values.domain | quote }}
   FETCHMAIL_DELAY: {{ .Values.fetchmail.delay | quote }}
   FETCHMAIL_ENABLED: {{ .Values.fetchmail.enabled | quote }}
-  FULL_TEXT_SEARCH: {{ include "mailu.fullTextSearch" . }}
   HOSTNAMES: {{ join "," .Values.hostnames }}
   INBOUND_TLS_ENFORCE: {{ .Values.tls.inboundEnforce | quote }}
   INSTANCE_ID_PATH: "/data/instance"
@@ -160,3 +159,11 @@ data:
 {{- else }}
   SCAN_MACROS: "false"
 {{- end }}
+
+{{- if .Values.tika.enabled }}
+  FULL_TEXT_SEARCH: {{ include "mailu.fullTextSearch" . }}
+  FULL_TEXT_SEARCH_ATTACHMENTS: "true"
+  FTS_ATTACHMENTS_ADDRESS: {{ include "mailu.tika.serviceFqdn" . }}
+{{- else }}
+  FULL_TEXT_SEARCH_ATTACHMENTS: "false"
+{{- end}}

--- a/mailu/templates/envvars-configmap.yaml
+++ b/mailu/templates/envvars-configmap.yaml
@@ -47,6 +47,7 @@ data:
   DOMAIN: {{ .Values.domain | quote }}
   FETCHMAIL_DELAY: {{ .Values.fetchmail.delay | quote }}
   FETCHMAIL_ENABLED: {{ .Values.fetchmail.enabled | quote }}
+  FULL_TEXT_SEARCH: {{ include "mailu.fullTextSearch" . }}
   HOSTNAMES: {{ join "," .Values.hostnames }}
   INBOUND_TLS_ENFORCE: {{ .Values.tls.inboundEnforce | quote }}
   INSTANCE_ID_PATH: "/data/instance"

--- a/mailu/templates/tika/deployment.yaml
+++ b/mailu/templates/tika/deployment.yaml
@@ -1,0 +1,128 @@
+---
+{{- if .Values.tika.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ printf "%s-tika" (include "mailu.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: tika
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  {{- if .Values.tika.updateStrategy }}
+  strategy: {{- toYaml .Values.tika.updateStrategy | nindent 4 }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.tika.revisionHistoryLimit }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tika
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: tika
+        {{- if .Values.tika.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.tika.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if .Values.tika.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.tika.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "common.images.pullSecrets" (dict "images" (list .Values.tika.image) "global" .Values.global) | nindent 6 }}
+      {{- if .Values.tika.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.tika.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.tika.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.affinity }}
+      affinity: {{- include "common.tplvalues.render" (dict "value" .Values.tika.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tika.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.priorityClassName }}
+      priorityClassName: {{ .Values.tika.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.tika.schedulerName }}
+      schedulerName: {{ .Values.tika.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.tika.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.tika.topologySpreadConstraints "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.tika.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if .Values.tika.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.tika.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.tika.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: tika
+          image: {{ .Values.clamav.image.registry }}/{{ .Values.clamav.image.repository }}:{{ .Values.clamav.image.tag }}
+          imagePullPolicy: {{ .Values.tika.image.pullPolicy }}
+          {{- if .Values.tika.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.tika.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.tika.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "common.tplvalues.render" (dict "value" .Values.tika.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: LOG_LEVEL
+              value: {{ default .Values.logLevel .Values.tika.logLevel }}
+            {{- tpl (include "mailu.envvars.secrets" .) $ | nindent 12 }}
+            {{- if .Values.tika.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.tika.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
+            {{- if .Values.tika.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.tika.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.tika.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.tika.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 9998
+              protocol: TCP
+          {{- if .Values.tika.resources }}
+          resources: {{- toYaml .Values.tika.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.tika.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tika.startupProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /tika
+              port: http
+          {{- end }}
+          {{- if .Values.tika.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tika.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /tika
+              port: http
+          {{- end }}
+          {{- if .Values.tika.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.tika.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /tika
+              port: http
+          {{- end }}
+      {{- if .Values.tika.extraContainers }}
+        {{- toYaml .Values.tika.extraContainers | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tika.extraVolumes }}
+      volumes:
+        {{- include "common.tplvalues.render" (dict "value" .Values.tika.extraVolumes "context" $) | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/mailu/templates/tika/deployment.yaml
+++ b/mailu/templates/tika/deployment.yaml
@@ -66,7 +66,7 @@ spec:
       {{- end }}
       containers:
         - name: tika
-          image: {{ .Values.clamav.image.registry }}/{{ .Values.clamav.image.repository }}:{{ .Values.clamav.image.tag }}
+          image: {{ .Values.tika.image.registry }}/{{ .Values.tika.image.repository }}:{{ .Values.tika.image.tag }}
           imagePullPolicy: {{ .Values.tika.image.pullPolicy }}
           {{- if .Values.tika.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.tika.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/mailu/templates/tika/service.yaml
+++ b/mailu/templates/tika/service.yaml
@@ -1,0 +1,23 @@
+---
+{{- if .Values.tika.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mailu.tika.serviceName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: tika
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.tika.service.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.tika.service.annotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: tika
+  ports:
+  - name: http
+    port: 9998
+    protocol: TCP
+{{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -2789,3 +2789,197 @@ oletools:
 
   ## @param oletools.extraContainers Add additional containers to the pod
   extraContainers: []
+
+## @section Tika parameters
+tika:
+  ## @param tika.enabled Enable OLETools
+  enabled: true
+
+  ## @param tika.logLevel Override default log level
+  logLevel: ""
+
+  ## @param tika.languages Array of languages to enable (sets the FULL_TEXT_SEARCH environment variable); "off" to disable
+  ## See https://doc.dovecot.org/settings/plugin/fts-plugin/#fts-languages for all available languages
+  languages:
+    - en
+
+  ## Pod image
+  ## @param tika.image.repository Pod image repository
+  ## @param tika.image.tag Pod image tag
+  ## @param tika.image.pullPolicy Pod image pull policy
+  ## @param tika.image.registry Pod image registry (specific for tika as it is not part of the mailu organization)
+  image:
+    repository: apache/tika
+    tag: 2.9.2.1-full
+    pullPolicy: IfNotPresent
+    registry: docker.io
+
+  ## Pod resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param tika.resources.limits The resources limits for the container
+  ## @param tika.resources.requests The requested resources for the container
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 500Mi
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##    cpu: 25m
+    ##    memory: 25Mi
+    requests: {}
+
+  ## Liveness probe values
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param tika.livenessProbe.enabled Enable livenessProbe
+  ## @param tika.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param tika.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param tika.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param tika.livenessProbe.successThreshold Success threshold for livenessProbe
+  ## @param tika.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  livenessProbe:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+
+  ## Readiness probe values
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param tika.readinessProbe.enabled Enable readinessProbe
+  ## @param tika.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param tika.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param tika.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param tika.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param tika.readinessProbe.successThreshold Success threshold for readinessProbe
+  readinessProbe:
+    enabled: true
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+
+  ## Startup probe values
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ## @param tika.startupProbe.enabled Enable startupProbe
+  ## @param tika.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param tika.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param tika.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param tika.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param tika.startupProbe.successThreshold Success threshold for startupProbe
+  startupProbe:
+    enabled: false
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+
+  ## @param tika.podLabels Add extra labels to pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+  ## @param tika.podAnnotations Add extra annotations to the pod
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  podAnnotations: {}
+
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ## @param tika.nodeSelector Node labels selector for pod assignment
+  nodeSelector: {}
+
+  ## @param tika.initContainers Add additional init containers to the pod
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  initContainers: []
+
+  ## @param tika.priorityClassName Pods' priorityClassName
+  priorityClassName: ""
+
+  ## @param tika.podSecurityContext.enabled Enabled pods' Security Context
+  ## @param tika.podSecurityContext.fsGroup Set pods' Security Context fsGroup
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  podSecurityContext:
+    enabled: false
+    fsGroup: 1001
+
+  ## @param tika.containerSecurityContext.enabled Enabled containers' Security Context
+  ## @param tika.containerSecurityContext.runAsUser Set containers' Security Context runAsUser
+  ## @param tika.containerSecurityContext.runAsNonRoot Set container's Security Context runAsNonRoot
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 1001
+    runAsNonRoot: false
+
+  ## @param tika.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  terminationGracePeriodSeconds: 2
+
+  ## @param tika.affinity Affinity for tika pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
+  ## @param tika.tolerations Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  ## @param tika.revisionHistoryLimit Configure the revisionHistoryLimit of the deployment
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#revision-history-limit
+  revisionHistoryLimit: 3
+
+  ## @param tika.hostAliases Pod pod host aliases
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  hostAliases: []
+
+  ## @param tika.schedulerName Name of the k8s scheduler (other than default)
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  schedulerName: ""
+
+  # Service parameters
+  service:
+    ## @param tika.service.annotations tika service annotations
+    annotations: {}
+
+  ## @param tika.topologySpreadConstraints Topology Spread Constraints for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+
+  ## Strategy to use to update Pods
+  ## @param tika.updateStrategy.type Can be set to RollingUpdate or OnDelete
+  updateStrategy:
+    type: RollingUpdate
+
+  ## @param tika.extraEnvVars Extra environment variable to pass to the running container
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: MY_ENV_VAR
+  ##    value: env_var_value
+  extraEnvVars: []
+
+  ## @param tika.extraEnvVarsCM Name of existing ConfigMap containing extra environment variables to mount in the pod
+  extraEnvVarsCM: ""
+
+  ## @param tika.extraEnvVarsSecret Name of existing Secret containing extra environment variables to mount in the pod
+  extraEnvVarsSecret: ""
+
+  ## @param tika.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the pod
+  extraVolumeMounts: []
+
+  ## @param tika.extraVolumes Optionally specify extra list of additional volumes for the pod(s)
+  extraVolumes: []
+
+  ## @param tika.extraContainers Add additional containers to the pod
+  extraContainers: []


### PR DESCRIPTION
This PR adds a deployment for Tika and allows to set `FULL_TEXT_SEARCH`.
https://mailu.io/2024.06/configuration.html

To enable it, set `tika.enabled` to `true`.
You can change the [languages](https://doc.dovecot.org/settings/plugin/fts-plugin/#fts-languages) to changing the configuration array `tika.languages` (defaults to `en` only).
