### PR TITLE
allow defining ipFamilyPolicy for external service

### DIFF
--- a/charts/mailu/README.md
+++ b/charts/mailu/README.md
@@ -329,6 +329,7 @@ helm uninstall mailu --namespace=mailu-mailserver
 | `front.externalService.type`                  | Service type (ClusterIP or LoadBalancer)                                              | `ClusterIP`     |
 | `front.externalService.externalTrafficPolicy` | Service externalTrafficPolicy (Cluster or Local)                                      | `Local`         |
 | `front.externalService.externalIPs`           | Service externalIPs                                                                   | `[]`            |
+| `front.externalService.ipFamilyPolicy`        | Service ipFamilyPolicy, for dual stack clusters.                                      | `""`            |
 | `front.externalService.loadBalancerIP`        | Service loadBalancerIP                                                                | `""`            |
 | `front.externalService.annotations`           | Service annotations                                                                   | `{}`            |
 | `front.externalService.labels`                | Service labels                                                                        | `{}`            |

--- a/charts/mailu/templates/front/service-external.yaml
+++ b/charts/mailu/templates/front/service-external.yaml
@@ -23,6 +23,9 @@ spec:
   type: {{ .type | default "ClusterIP" }}
   {{- if ne .type "ClusterIP" }}
   externalTrafficPolicy: {{ .externalTrafficPolicy | default "Local" }}
+  {{- with .ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . | quote }}
+  {{- end }}
   {{- end }}
   {{- if .loadBalancerIP }}
   loadBalancerIP: {{ .loadBalancerIP }}

--- a/charts/mailu/values.yaml
+++ b/charts/mailu/values.yaml
@@ -720,6 +720,7 @@ front:
   ## @param front.externalService.type Service type (ClusterIP or LoadBalancer)
   ## @param front.externalService.externalTrafficPolicy Service externalTrafficPolicy (Cluster or Local)
   ## @param front.externalService.externalIPs Service externalIPs
+  ## @param front.externalService.ipFamilyPolicy Service ipFamilyPolicy, for dual stack clusters.
   ## @param front.externalService.loadBalancerIP Service loadBalancerIP
   ## @param front.externalService.annotations Service annotations
   ## @param front.externalService.labels Service labels
@@ -747,6 +748,7 @@ front:
     loadBalancerIP: ""
     externalTrafficPolicy: Local
     externalIPs: []
+    ipFamilyPolicy: ""
     annotations: {}
     labels: {}
     ports:


### PR DESCRIPTION
For dual stack (IPv4 and IPv6) clusters, services need to be explicitly opted-in into having two addresses. This is done through the `ipFamilyPolicy` field, as documented in https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services.

I've wired the templates in a way where if this field is not present, nothing is rendered. This preserves the usual behavior of not specifying this value altogether for services.