### PR TITLE
Only set the externTrafficPolicy when spec.type is not ClusterIP

### DIFF
--- a/mailu/templates/front/service-external.yaml
+++ b/mailu/templates/front/service-external.yaml
@@ -18,7 +18,9 @@ spec:
     app.kubernetes.io/component: front
 {{- with .Values.front.externalService }}
   type: {{ .type | default "ClusterIP" }}
+  {{- if ne $.Values.front.externalService.type "ClusterIP" -}}
   externalTrafficPolicy: {{ .externalTrafficPolicy | default "Local" }}
+  {{- end }}
   {{- if .loadBalancerIP }}
   loadBalancerIP: {{ .loadBalancerIP }}
   {{- end }}


### PR DESCRIPTION
Setting the `externalTrafficPolicy` to anything non-default is not supported on `ClusterIP` as per https://github.com/kubernetes/kubernetes/issues/67202

Fixes #266 