### PR TITLE
Fix issue with redis subpath needing to be relative

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -449,7 +449,7 @@ Check that the deployed pods are all running.
 | `redis.master.persistence.accessModes`   | Pod pvc access modes                                                | `["ReadWriteOnce"]` |
 | `redis.master.persistence.annotations`   | Pod pvc annotations                                                 | `{}`                |
 | `redis.master.persistence.existingClaim` | Pod pvc existing claim; necessary if using single_pvc               | `""`                |
-| `redis.master.persistence.subPath`       | Subpath in PVC; necessary if using single_pvc (set it to `/redis`)  | `""`                |
+| `redis.master.persistence.subPath`       | Subpath in PVC; necessary if using single_pvc (set it to `redis`)   | `""`                |
 | `redis.replica.count`                    | Number of redis replicas (only if `redis.architecture=replication`) | `0`                 |
 
 ### Postfix parameters

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1113,7 +1113,7 @@ redis:
     ## @param redis.master.persistence.accessModes Pod pvc access modes
     ## @param redis.master.persistence.annotations Pod pvc annotations
     ## @param redis.master.persistence.existingClaim Pod pvc existing claim; necessary if using single_pvc
-    ## @param redis.master.persistence.subPath Subpath in PVC; necessary if using single_pvc (set it to `/redis`)
+    ## @param redis.master.persistence.subPath Subpath in PVC; necessary if using single_pvc (set it to `redis`)
     persistence:
       enabled: true
       size: 8Gi


### PR DESCRIPTION
The `mailu-redis-master-0` pod failed to be created when using absolute path `/redis` for redis.master.persistence.subPath. However, removing the leading `/` fixed it. 