### PR TITLE
feat: allow externalService nodePort to be set

### DIFF
--- a/mailu/templates/front/service-external.yaml
+++ b/mailu/templates/front/service-external.yaml
@@ -28,7 +28,7 @@ spec:
       port: 110
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 110
+      nodePort: {{ .nodePorts.pop3 | default 110 }}
       {{- end }}
     {{- end }}
     {{- if .ports.pop3s }}
@@ -36,7 +36,7 @@ spec:
       port: 995
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 995
+      nodePort: {{ .nodePorts.pop3s | default 995 }}
       {{- end }}
     {{- end }}
     {{- if .ports.imap }}
@@ -44,7 +44,7 @@ spec:
       port: 143
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 143
+      nodePort: {{ .nodePorts.imap | default 143 }}
       {{- end }}
     {{- end }}
     {{- if .ports.imaps }}
@@ -52,7 +52,7 @@ spec:
       port: 993
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 993
+      nodePort: {{ .nodePorts.imaps | default 993 }}
       {{- end }}
     {{- end }}
     {{- if .ports.smtp }}
@@ -60,7 +60,7 @@ spec:
       port: 25
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 25
+      nodePort: {{ .nodePorts.smtp | default 25 }}
       {{- end }}
     {{- end }}
     {{- if .ports.smtps }}
@@ -68,7 +68,7 @@ spec:
       port: 465
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 465
+      nodePort: {{ .nodePorts.smtps | default 465 }}
       {{- end }}
     {{- end }}
     {{- if .ports.submission }}
@@ -76,7 +76,7 @@ spec:
       port: 587
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 587
+      nodePort: {{ .nodePorts.submission | default 587 }}
       {{- end }}
     {{- end }}
     {{- if .ports.manageSieve }}
@@ -84,7 +84,7 @@ spec:
       port: 4190
       protocol: TCP
       {{ if eq $.Values.front.externalService.type "NodePort" -}}
-      nodePort: 4190
+      nodePort: {{ .nodePorts.manageSieve | default 4190 }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -704,6 +704,15 @@ front:
       smtps: true
       submission: false
       manageSieve: true
+    nodePorts:
+      pop3: 110
+      pop3s: 995
+      imap: 143
+      imaps: 993
+      smtp: 25
+      smtps: 465
+      submission: 587
+      manageSieve: 4190
 
   ## @param front.kind Kind of resource to create for the front (`Deployment` or `DaemonSet`)
   kind: Deployment


### PR DESCRIPTION
Hello,

The node port values are hardcoded, and falls outside my allowed nodePort range. This update allows to change nodePort values for each port.