### PR TITLE
Fix frontend deployment and service

### DIFF
--- a/mailu/templates/front/deployment.yaml
+++ b/mailu/templates/front/deployment.yaml
@@ -167,27 +167,21 @@ spec:
           {{- end }}
           {{- if .Values.front.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.front.startupProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - sh
-                - -c
-                - 'curl -skfLo /dev/null http://127.0.0.1:10204/health && kill -0 `cat /run/dovecot/master.pid`'
+            httpGet:
+              path: /health
+              port: http
           {{- end }}
           {{- if .Values.front.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.front.livenessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - sh
-                - -c
-                - 'curl -skfLo /dev/null http://127.0.0.1:10204/health && kill -0 `cat /run/dovecot/master.pid`'
+            httpGet:
+              path: /health
+              port: http
           {{- end }}
           {{- if .Values.front.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.front.readinessProbe "enabled") "context" $) | nindent 12 }}
-            exec:
-              command:
-                - sh
-                - -c
-                - 'curl -skfLo /dev/null http://127.0.0.1:10204/health && kill -0 `cat /run/dovecot/master.pid`'
+            httpGet:
+              path: /health
+              port: http
           {{- end }}
       {{- if .Values.front.extraContainers }}
         {{- toYaml .Values.front.extraContainers | nindent 8 }}

--- a/mailu/templates/front/ingress.yaml
+++ b/mailu/templates/front/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,7 +34,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "https" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name | quote }}
@@ -44,7 +44,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "https" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}


### PR DESCRIPTION
Hi, this changeset addresses two issus I have ran into with my Mailu installation.

First, the ingress could never work correctly, because the ingress had `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` annotation, while the deployment explicitly disables HTTPS port when `ingress.enabled` is set.

Second, the change in front deployment probes introduced in 3fa16db1 breaks the probes. They try to check whether dovecot is running, while the container only runs nginx. I guess, that change was meant for a different deployment, although I may be missing something.