### PR TITLE
feat: support mta-sts configuration with overrides

### DIFF
--- a/mailu/templates/front/configmap.yaml
+++ b/mailu/templates/front/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.front.overrides }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-front-override" (include "mailu.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: front
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- with .Values.front.overrides }}
+data:
+{{- .|toYaml|nindent 2 }}
+{{ end }}
+{{ end }}

--- a/mailu/templates/front/deployment.yaml
+++ b/mailu/templates/front/deployment.yaml
@@ -78,6 +78,10 @@ spec:
           volumeMounts:
             - name: certs
               mountPath: /certs
+            {{- if .Values.front.overrides }}
+            - name: overrides
+              mountPath: /overrides
+            {{- end }}
             {{- if .Values.front.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.front.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -201,6 +205,11 @@ spec:
               - key: tls.key
                 path: key.pem
             secretName: {{ include "mailu.certificatesSecretName" . }}
+        {{- if .Values.front.overrides }}
+        - name: overrides
+          configMap:
+            name: {{ printf "%s-front-override" (include "mailu.fullname" .) }}
+        {{- end }}
         {{- if .Values.front.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.front.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -900,6 +900,16 @@ front:
   ## @param front.extraContainers Add additional containers to the pod
   extraContainers: []
 
+  ## @param front.overrides Enable front overrides
+  ## Example:
+  ## overrides:
+  ##   mta-sts.conf: |
+  ##      # More info here: https://mailu.io/master/faq.html#how-do-i-setup-a-mta-sts-policy
+  ##      location ^~ /.well-known/mta-sts.txt {
+  ##        return 200 "version: STSv1\nmode: enforce\nmax_age: 1296000\nmx: mailu.example.com\n";
+  ##      }
+  overrides: {}
+
 ## @section Admin parameters
 admin:
   ## @param admin.enabled Enable access to the admin interface


### PR DESCRIPTION
With this PR allow users to expose the MTA-STS policy using the overrides for the POD front. As suggested in the [FAQ](https://mailu.io/master/faq.html#how-do-i-setup-a-mta-sts-policy).

