### PR TITLE
fix: Enabling proxy-protocol performs faulty values validation

### DIFF
--- a/mailu/templates/_services.tpl
+++ b/mailu/templates/_services.tpl
@@ -240,14 +240,14 @@ Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
 {{- end -}}
 
 {{- $proxyProtocolPortsString := join "," $proxyProtocolPorts -}}
-{{/* if any ports are enabled and .front.realIpFrom is empty, fail */}}
-{{- if and (gt (len $proxyProtocolPorts) 0) (not .Values.front.realIpFrom) -}}
-    {{- fail "PROXY protocol is enabled for some ports, but front.realIpFrom is not set" -}}
+{{/* if any ports are enabled and .ingress.realIpFrom is empty, fail */}}
+{{- if and (gt (len $proxyProtocolPorts) 0) (not .Values.ingress.realIpFrom) -}}
+    {{- fail "PROXY protocol is enabled for some ports, but ingress.realIpFrom is not set" -}}
 {{- end -}}
 
-{{/* if any ports are enabled and .front.realIpHeader is set, fail */}}
-{{- if and (gt (len $proxyProtocolPorts) 0) .Values.front.realIpHeader -}}
-    {{- fail "PROXY protocol is enabled for some ports, but front.realIpHeader is set" -}}
+{{/* if any ports are enabled and .ingress.realIpHeader is set, fail */}}
+{{- if and (gt (len $proxyProtocolPorts) 0) .Values.ingress.realIpHeader -}}
+    {{- fail "PROXY protocol is enabled for some ports, but ingress.realIpHeader is set" -}}
 {{- end -}}
 
 {{- printf "%s" $proxyProtocolPortsString -}}


### PR DESCRIPTION
If one of the `front.externalService.ports` is enabled, then the proxy-protocol gets enabled implicitly and the existence of the `front.realIpFrom` / `front.realIpHeader` values is asserted.

Neither `front.realIpFrom` nor `front.realIpHeader` are document or referenced anywhere.
A check for `ingress.realIpFrom` / `ingress.realIpHeader` was probably intended instead.