### PR TITLE
Opened manage sieve port in host port mode

### DIFF
--- a/mailu/templates/_services.tpl
+++ b/mailu/templates/_services.tpl
@@ -177,6 +177,10 @@ Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
     {{- $enabledPorts = append $enabledPorts "443" -}}
 {{- end -}}
 
+{{- if .Values.front.hostPort.enabled -}}
+    {{- $enabledPorts = append $enabledPorts "4190" -}}
+{{- end -}}
+
 {{- if .Values.front.externalService.enabled -}}
     {{- if .Values.front.externalService.ports.pop3 -}}
         {{- $enabledPorts = append $enabledPorts "110" -}}


### PR DESCRIPTION
Fixes https://github.com/Mailu/helm-charts/issues/394

## Issue

- Manage sieve port is not opened when using host port mode
  - Creating sieves via UI fails

## Changes

- Opened manage sieve port when using host port mode