### PR TITLE
fix: fix clamav probes

### DIFF
--- a/mailu/README.md
+++ b/mailu/README.md
@@ -667,7 +667,7 @@ Check that the deployed pods are all running.
 | `clamav.resources.limits`                      | The resources limits for the container                                                | `{}`                   |
 | `clamav.resources.requests`                    | The requested resources for the container                                             | `{}`                   |
 | `clamav.livenessProbe.enabled`                 | Enable livenessProbe                                                                  | `true`                 |
-| `clamav.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `3`                    |
+| `clamav.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                   | `5`                    |
 | `clamav.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                               | `10`                   |
 | `clamav.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                      | `10`                   |
 | `clamav.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                   | `1`                    |

--- a/mailu/templates/clamav/statefulset.yaml
+++ b/mailu/templates/clamav/statefulset.yaml
@@ -107,26 +107,17 @@ spec:
           {{- if .Values.clamav.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clamav.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command:
-                - sh
-                - -c
-                - 'kill -0 `cat /tmp/clamd.pid` && kill -0 `cat /tmp/freshclam.pid`'
+              command: ["echo", "PING", "|", "nc", "localhost", "3310", "|", "grep", "PONG"]
           {{- end }}
           {{- if .Values.clamav.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clamav.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command:
-                - sh
-                - -c
-                - 'kill -0 `cat /tmp/clamd.pid` && kill -0 `cat /tmp/freshclam.pid`'
+              command: ["echo", "PING", "|", "nc", "localhost", "3310", "|", "grep", "PONG"]
           {{- end }}
           {{- if .Values.clamav.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clamav.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command:
-                - sh
-                - -c
-                - 'kill -0 `cat /tmp/clamd.pid` && kill -0 `cat /tmp/freshclam.pid`'
+              command: ["echo", "PING", "|", "nc", "localhost", "3310", "|", "grep", "PONG"]
           {{- end }}
       {{- if .Values.clamav.extraContainers }}
         {{- toYaml .Values.clamav.extraContainers | nindent 8 }}

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1865,7 +1865,7 @@ clamav:
   ## @param clamav.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
   livenessProbe:
     enabled: true
-    failureThreshold: 3
+    failureThreshold: 5
     initialDelaySeconds: 10
     periodSeconds: 10
     successThreshold: 1


### PR DESCRIPTION
This pull request introduces updates to the ClamAV configuration in the Mailu project, focusing on improving the health check mechanisms and updating the default failure threshold for the liveness probe. The most important changes are grouped below:

### Health Check Improvements:
* Updated the commands for `startupProbe`, `livenessProbe`, and `readinessProbe` in `mailu/templates/clamav/statefulset.yaml` to use a network-based health check (`echo "PING" | nc localhost 3310 | grep "PONG"`) instead of process-based checks. This ensures a more robust and accurate health check mechanism.

### Configuration Updates:
* Changed the default value of `clamav.livenessProbe.failureThreshold` from `3` to `5` in `mailu/README.md` and `mailu/values.yaml` to allow more retries before marking the container as unhealthy. [[1]](diffhunk://#diff-79ce832d84f3321859866cca57422a5f01d36caf7167ce353f1d811951753269L670-R670) [[2]](diffhunk://#diff-50d55ccb9dc108e0535254e89f32431b5c0342b715685820c80f5f5ff3410a03L1868-R1868)