### PR TITLE
fix: update mailu to 2024.06.36 and clamav to 1.4

### DIFF
--- a/mailu/Chart.yaml
+++ b/mailu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2024.06.10
+appVersion: 2024.06.36
 version: 2.1.2
 name: mailu
 description: This chart installs the Mailu mail system on kubernetes

--- a/mailu/README.md
+++ b/mailu/README.md
@@ -652,7 +652,7 @@ Check that the deployed pods are all running.
 | `clamav.enabled`                               | Enable ClamAV                                                                         | `true`                 |
 | `clamav.logLevel`                              | Override default log level                                                            | `""`                   |
 | `clamav.image.repository`                      | Pod image repository                                                                  | `clamav/clamav-debian` |
-| `clamav.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `1.2.0-6`              |
+| `clamav.image.tag`                             | Pod image tag (defaults to mailuVersion if set, otherwise Chart.AppVersion)           | `1.4`                  |
 | `clamav.image.pullPolicy`                      | Pod image pull policy                                                                 | `IfNotPresent`         |
 | `clamav.image.registry`                        | Pod image registry (specific for clamav as it is not part of the mailu organization)  | `docker.io`            |
 | `clamav.persistence.enabled`                   | Enable persistence using PVC                                                          | `true`                 |

--- a/mailu/values.yaml
+++ b/mailu/values.yaml
@@ -1796,7 +1796,7 @@ clamav:
   ## @param clamav.image.registry Pod image registry (specific for clamav as it is not part of the mailu organization)
   image:
     repository: clamav/clamav-debian
-    tag: 1.2.0-6
+    tag: 1.4
     pullPolicy: IfNotPresent
     registry: docker.io
 


### PR DESCRIPTION
This pull request updates the Mailu Helm chart with a new application version and updates the ClamAV image tag to a more recent version. Below are the most important changes grouped by theme.

### Application Version Update:
* Updated `appVersion` in `mailu/Chart.yaml` from `2024.06.10` to `2024.06.36`, reflecting a new application release.

### ClamAV Image Update:
* Updated the ClamAV image tag in `mailu/README.md` and `mailu/values.yaml` from `1.2.0-6` to `1.4`, ensuring the use of a newer version of the ClamAV image. [[1]](diffhunk://#diff-79ce832d84f3321859866cca57422a5f01d36caf7167ce353f1d811951753269L655-R655) [[2]](diffhunk://#diff-50d55ccb9dc108e0535254e89f32431b5c0342b715685820c80f5f5ff3410a03L1799-R1799)