### PR TITLE
fix: fixed publish pipeline

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -48,7 +48,7 @@ jobs:
           helm dependency build charts/mailu
 
       - name: Run helm lint
-        run: helm lint --strict --values charts/mailu/ci/helm-lint-values.yaml mailu
+        run: helm lint --strict --values charts/mailu/ci/helm-lint-values.yaml charts/mailu
 
       - name: Install chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
@@ -57,7 +57,7 @@ jobs:
 
       - name: Package Chart with chart-releaser
         run: |
-          cr package mailu
+          cr package charts/mailu
 
       - name: Get Release
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-chart.yaml` file to fix paths related to the Helm chart and ensure consistency in the workflow.

### Workflow adjustments for Helm chart:

* Updated the `helm lint` command to use the correct path `charts/mailu` instead of `mailu`, ensuring the command runs in the appropriate directory.
* Adjusted the `cr package` command to package the Helm chart from the correct path `charts/mailu` instead of `mailu`, aligning with the updated directory structure.