### PR TITLE
fix: fix proxy protocol check

### DIFF
--- a/charts/mailu/templates/_services.tpl
+++ b/charts/mailu/templates/_services.tpl
@@ -213,28 +213,28 @@ Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
 {{- $proxyProtocolPorts := list -}}
 
 {{- if .Values.front.externalService.enabled -}}
-    {{- if .Values.front.externalService.ports.pop3 -}}
+    {{- if and .Values.front.externalService.ports.pop3 .Values.ingress.proxyProtocol.pop3 -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "110" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.pop3s -}}
+    {{- if and .Values.front.externalService.ports.pop3s .Values.ingress.proxyProtocol.pop3s -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "995" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.imap -}}
+    {{- if and .Values.front.externalService.ports.imap .Values.ingress.proxyProtocol.imap -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "143" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.imaps -}}
+    {{- if and .Values.front.externalService.ports.imaps .Values.ingress.proxyProtocol.imaps -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "993" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.smtp -}}
+    {{- if and .Values.front.externalService.ports.smtp .Values.ingress.proxyProtocol.smtp -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "25" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.smtps -}}
+    {{- if and .Values.front.externalService.ports.smtps .Values.ingress.proxyProtocol.smtps -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "465" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.submission -}}
+    {{- if and .Values.front.externalService.ports.submission .Values.ingress.proxyProtocol.submission -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "587" -}}
     {{- end -}}
-    {{- if .Values.front.externalService.ports.manageSieve -}}
+    {{- if and .Values.front.externalService.ports.manageSieve .Values.ingress.proxyProtocol.manageSieve -}}
         {{- $proxyProtocolPorts = append $proxyProtocolPorts "4190" -}}
     {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This pull request updates the logic in the `_services.tpl` file to align with the new configuration structure for handling PROXY protocol settings. Specifically, it replaces references to `front.realIpFrom` and `front.realIpHeader` with `ingress.realIpFrom` and `ingress.realIpHeader`, ensuring consistency with the updated configuration schema.

Key changes:

* Updated the validation logic to check for `ingress.realIpFrom` instead of `front.realIpFrom` when PROXY protocol is enabled for certain ports.
* Updated the validation logic to check for `ingress.realIpHeader` instead of `front.realIpHeader` when PROXY protocol is enabled for certain ports.

closes #398 