### PR TITLE
Fix (container) securityContext for admin

### DIFF
--- a/charts/mailu/templates/admin/deployment.yaml
+++ b/charts/mailu/templates/admin/deployment.yaml
@@ -67,9 +67,6 @@ spec:
         - name: admin
           image: {{ .Values.imageRegistry }}/{{ .Values.admin.image.repository }}:{{ default (include "mailu.version" .) .Values.admin.image.tag }}
           imagePullPolicy: {{ .Values.admin.image.pullPolicy }}
-          {{- if .Values.admin.containerSecurityContext.enabled }}
-          securityContext: {{- omit .Values.admin.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-          {{- end }}
           volumeMounts:
             - name: data
               subPath: admin
@@ -126,9 +123,11 @@ spec:
               port: http
           {{- end }}
           securityContext:
-            capabilities:
-              add:
-                - NET_BIND_SERVICE
+            {{- $securityContext := dict "capabilities" (dict "add" (list "NET_BIND_SERVICE")) }}
+            {{- if .Values.admin.containerSecurityContext }}
+            {{- $securityContext = merge $securityContext (omit .Values.admin.containerSecurityContext "enabled") }}
+            {{- end }}
+            {{- toYaml $securityContext | nindent 12 }}
       {{- if .Values.admin.extraContainers }}
         {{- toYaml .Values.admin.extraContainers | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
If the `containerSecurityContext` is set it results in two securityContext keys which causes the helm chart to fail.