### PR TITLE
fix: remove env vars from clamav, oletools and tika pods

### DIFF
--- a/charts/mailu/templates/clamav/statefulset.yaml
+++ b/charts/mailu/templates/clamav/statefulset.yaml
@@ -86,9 +86,8 @@ spec:
             {{- if .Values.clamav.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.clamav.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if or .Values.clamav.extraEnvVarsCM .Values.clamav.extraEnvVarsSecret }}
           envFrom:
-            - configMapRef:
-                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.clamav.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.clamav.extraEnvVarsCM "context" $) }}
@@ -97,6 +96,7 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.clamav.extraEnvVarsSecret "context" $) }}
             {{- end }}
+          {{- end }}
           ports:
             - name: clamav
               containerPort: 3310

--- a/charts/mailu/templates/oletools/deployment.yaml
+++ b/charts/mailu/templates/oletools/deployment.yaml
@@ -82,9 +82,8 @@ spec:
             {{- if .Values.oletools.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.oletools.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if or .Values.oletools.extraEnvVarsCM .Values.oletools.extraEnvVarsSecret }}
           envFrom:
-            - configMapRef:
-                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.oletools.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.oletools.extraEnvVarsCM "context" $) }}
@@ -93,6 +92,7 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.oletools.extraEnvVarsSecret "context" $) }}
             {{- end }}
+          {{- end }}
           ports:
             - name: olefy
               containerPort: 11343

--- a/charts/mailu/templates/tika/deployment.yaml
+++ b/charts/mailu/templates/tika/deployment.yaml
@@ -82,9 +82,8 @@ spec:
             {{- if .Values.tika.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.tika.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if or .Values.tika.extraEnvVarsCM .Values.tika.extraEnvVarsSecret }}
           envFrom:
-            - configMapRef:
-                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.tika.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.tika.extraEnvVarsCM "context" $) }}
@@ -93,6 +92,7 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.tika.extraEnvVarsSecret "context" $) }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 9998

--- a/charts/mailu/templates/webdav/deployment.yaml
+++ b/charts/mailu/templates/webdav/deployment.yaml
@@ -85,9 +85,8 @@ spec:
             {{- if .Values.webdav.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.webdav.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if or .Values.webdav.extraEnvVarsCM .Values.webdav.extraEnvVarsSecret }}
           envFrom:
-            - configMapRef:
-                name: {{ printf "%s-envvars" (include "mailu.fullname" .) }}
             {{- if .Values.webdav.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.webdav.extraEnvVarsCM "context" $) }}
@@ -96,6 +95,7 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.webdav.extraEnvVarsSecret "context" $) }}
             {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 5232


### PR DESCRIPTION
This pull request updates the way environment variables are injected into several Mailu service templates, improving flexibility and consistency across deployments. The main change is to conditionally include the `envFrom` block only when either a ConfigMap or Secret is specified, and to remove the default reference to a standard ConfigMap. This allows for more granular control of environment variable sources for each service.

**Improvements to environment variable injection:**

* [`charts/mailu/templates/clamav/statefulset.yaml`](diffhunk://#diff-c38dfb712deaac1c54a12e9533d9c3ceee65a23bff5d3bd799608c4030cf4360R89-L91): The `envFrom` block is now only included if either `clamav.extraEnvVarsCM` or `clamav.extraEnvVarsSecret` is set, and the default ConfigMap reference has been removed. [[1]](diffhunk://#diff-c38dfb712deaac1c54a12e9533d9c3ceee65a23bff5d3bd799608c4030cf4360R89-L91) [[2]](diffhunk://#diff-c38dfb712deaac1c54a12e9533d9c3ceee65a23bff5d3bd799608c4030cf4360R99)
* [`charts/mailu/templates/oletools/deployment.yaml`](diffhunk://#diff-322a5871a21261c47a35a933d781d946e9b8510203443fa60325e5cb4a702ac9R85-L87): The `envFrom` block is now conditionally included based on `oletools.extraEnvVarsCM` or `oletools.extraEnvVarsSecret`, removing the default ConfigMap reference. [[1]](diffhunk://#diff-322a5871a21261c47a35a933d781d946e9b8510203443fa60325e5cb4a702ac9R85-L87) [[2]](diffhunk://#diff-322a5871a21261c47a35a933d781d946e9b8510203443fa60325e5cb4a702ac9R95)
* [`charts/mailu/templates/tika/deployment.yaml`](diffhunk://#diff-2236930425ab2ad3822471df5e71e37da7cf31700c43b5de2d7b43fd9805aa57R85-L87): The `envFrom` block is only added if `tika.extraEnvVarsCM` or `tika.extraEnvVarsSecret` is set, and the default ConfigMap reference is removed. [[1]](diffhunk://#diff-2236930425ab2ad3822471df5e71e37da7cf31700c43b5de2d7b43fd9805aa57R85-L87) [[2]](diffhunk://#diff-2236930425ab2ad3822471df5e71e37da7cf31700c43b5de2d7b43fd9805aa57R95)
* [`charts/mailu/templates/webdav/deployment.yaml`](diffhunk://#diff-3646884a29c25e96155d008acb8c5d24ae9f5be8b4dc1afe661f813114ed5fe6R88-L90): The `envFrom` block is now conditionally included based on `webdav.extraEnvVarsCM` or `webdav.extraEnvVarsSecret`, with the default ConfigMap reference removed. [[1]](diffhunk://#diff-3646884a29c25e96155d008acb8c5d24ae9f5be8b4dc1afe661f813114ed5fe6R88-L90) [[2]](diffhunk://#diff-3646884a29c25e96155d008acb8c5d24ae9f5be8b4dc1afe661f813114ed5fe6R98)