### PR TITLE
fix: update tika (CVE-2025-54988)

### DIFF
--- a/charts/mailu/README.md
+++ b/charts/mailu/README.md
@@ -956,7 +956,7 @@ Check that the deployed pods are all running.
 | `tika.logLevel`                              | Override default log level                                                                      | `""`            |
 | `tika.languages`                             | Array of languages to enable (sets the FULL_TEXT_SEARCH environment variable); "off" to disable | `["en"]`        |
 | `tika.image.repository`                      | Pod image repository                                                                            | `apache/tika`   |
-| `tika.image.tag`                             | Pod image tag                                                                                   | `2.9.2.1-full`  |
+| `tika.image.tag`                             | Pod image tag                                                                                   | `latest-full`   |
 | `tika.image.pullPolicy`                      | Pod image pull policy                                                                           | `IfNotPresent`  |
 | `tika.image.registry`                        | Pod image registry (specific for tika as it is not part of the mailu organization)              | `docker.io`     |
 | `tika.resources.limits`                      | The resources limits for the container                                                          | `{}`            |

--- a/charts/mailu/values.yaml
+++ b/charts/mailu/values.yaml
@@ -2839,7 +2839,7 @@ tika:
   ## @param tika.image.registry Pod image registry (specific for tika as it is not part of the mailu organization)
   image:
     repository: apache/tika
-    tag: 2.9.2.1-full
+    tag: latest-full
     pullPolicy: IfNotPresent
     registry: docker.io
 


### PR DESCRIPTION
This pull request updates the default Tika container image version used in the Mailu Helm chart from a specific version to the latest available full build. The goal is to ensure deployments use the most recent Tika features and fixes by default.

This addresses CVE-2025-54988, more information Mailu repository: https://github.com/Mailu/Mailu/pull/3904

Image version update:

* Changed the default value of `tika.image.tag` from `2.9.2.1-full` to `latest-full` in both the `values.yaml` configuration and the documentation table in `README.md`. [[1]](diffhunk://#diff-5ebc1aa2b8f6aa053cf9293c662865f975add4bade6e40262c8bf7f010b08ca5L2842-R2842) [[2]](diffhunk://#diff-3e8fc6668e30f58c499d4d7cd36004d6937cbc884ce7b7af654377a818afd8b3L959-R959)