### PR TITLE
 feat: bump mailu version to 2024.06.41

### DIFF
--- a/charts/mailu/Chart.yaml
+++ b/charts/mailu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2024.06.36
+appVersion: 2024.06.41
 version: 2.2.2
 name: mailu
 description: This chart installs the Mailu mail system on kubernetes


### PR DESCRIPTION
This pull request updates the Mailu Helm chart to use a newer application version.

- Version bump:
  * Updated the `appVersion` in `charts/mailu/Chart.yaml` from `2024.06.36` to `2024.06.41` to deploy the latest Mailu release.