### PR TITLE
fix: restrict tika and oletools internet access

### DIFF
--- a/charts/mailu/ci/helm-lint-values.yaml
+++ b/charts/mailu/ci/helm-lint-values.yaml
@@ -65,6 +65,23 @@ admin:
     limits:
       memory: 500Mi
       cpu: 1
+  initContainers:
+    # Add an initcontainer to wait for redis to be deployed
+    - name: wait-for-redis
+      image: busybox:1.34
+      command:
+        [
+          "sh",
+          "-c",
+          'until nc -z -v -w30 {{ template "mailu.redis.serviceFqdn" . }} {{ template "mailu.redis.port" . }}; do echo "Waiting for redis..."; sleep 5; done;',
+        ]
+      resources:
+        requests:
+          memory: 50Mi
+          cpu: 10m
+        limits:
+          memory: 100Mi
+          cpu: 50m
 
 postfix:
   logLevel: INFO

--- a/charts/mailu/templates/network-policies.yaml
+++ b/charts/mailu/templates/network-policies.yaml
@@ -38,11 +38,15 @@ spec:
   podSelector:
     matchLabels:
       app.kubernetes.io/instance: {{ .Release.Name }}
+    matchExpressions:
+      # Exclude tika and oletools from unrestricted internet access
+      - key: app.kubernetes.io/component
+        operator: NotIn
+        values: ["tika", "oletools"]
   policyTypes:
     - Egress
   egress:
     - {}
----
 ---
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
@@ -117,4 +121,46 @@ spec:
         podSelector:
           matchLabels:
             app.kubernetes.io/instance: {{ .Release.Name }}
+---
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-deny-oletools-egress" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: oletools
+  policyTypes:
+    - Egress
+  egress: []
+---
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-deny-tika-egress" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: tika
+  policyTypes:
+    - Egress
+  egress: []
 {{- end }}


### PR DESCRIPTION
This pull request strengthens network security for the Mailu Helm chart by restricting egress (outbound) internet access for the `tika` and `oletools` components. The changes ensure that these components cannot access the internet unless explicitly allowed, while other components retain their existing egress permissions.

**Network Policy Enhancements:**

* Updated the main network policy to explicitly exclude `tika` and `oletools` pods from unrestricted egress access using `matchExpressions` in the `podSelector`.
* Added two new `NetworkPolicy` resources that deny all egress traffic for pods with the `app.kubernetes.io/component` label set to `tika` and `oletools`, respectively.