### PR TITLE
feat: new dependency chart proposal for redis

### DIFF
--- a/charts/mailu/Chart.lock
+++ b/charts/mailu/Chart.lock
@@ -3,13 +3,13 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.8.0
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 17.15.2
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.1.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.13
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 12.2.9
-digest: sha256:418939e4cffeabd09d5a87f643f1fc87b43f23b00a9139d36646fcb11ebf4c17
-generated: "2023-08-14T00:40:16.960741779+02:00"
+digest: sha256:c7360d44c34c8decacc379897de5781f5c10fe5f639ec0a60c371520fae30b21
+generated: "2025-08-23T21:45:41.781862919+02:00"

--- a/charts/mailu/Chart.yaml
+++ b/charts/mailu/Chart.yaml
@@ -29,8 +29,8 @@ dependencies:
     version: 2.8.0
   - condition: redis.enabled
     name: redis
-    version: 17.15.*
-    repository: https://charts.bitnami.com/bitnami
+    version: 0.1.5
+    repository: oci://registry-1.docker.io/cloudpirates
   - condition: postgresql.enabled
     name: postgresql
     version: 11.9.*

--- a/charts/mailu/templates/_services.tpl
+++ b/charts/mailu/templates/_services.tpl
@@ -77,7 +77,7 @@ Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
 
 {{/* Returns redis internal service name. */}}
 {{- define "mailu.redis.serviceName" -}}
-{{- printf "%s-master" (include "common.names.dependency.fullname" (dict "chartName" "redis" "chartValues" .Values.redis "context" $)) -}}
+{{- printf "%s" (include "common.names.dependency.fullname" (dict "chartName" "redis" "chartValues" .Values.redis "context" $)) -}}
 {{- end -}}
 {{/* Returns redis service fqdn. */}}
 {{- define "mailu.redis.serviceFqdn" -}}

--- a/charts/mailu/values.yaml
+++ b/charts/mailu/values.yaml
@@ -1105,45 +1105,34 @@ admin:
 
 ## @section Redis parameters
 ## Redis chart configuration
-## for more options see https://github.com/bitnami/charts/tree/master/bitnami/redis
+## for more options see https://github.com/CloudPirates-io/helm-charts/tree/main/charts/redis
 redis:
   ## @param redis.enabled Enable redis deployment through the redis subchart
   enabled: true
 
   ## @param redis.architecture Redis architecture. Allowed values: `standalone` or `replication`
   architecture: standalone
+  image:
+    tag: 7.2.10
+    pullPolicy: IfNotPresent
 
   ## @param redis.auth.enabled DON'T CHANGE THIS VALUE. Mailu doesn't support Redis authentication
   auth:
     enabled: false
 
-  master:
-    ## @param redis.master.enabled DON'T CHANGE THIS VALUE. Enable redis master
+  persistence:
+    ## @param persistence.enabled Enable persistent storage
     enabled: true
-
-    ## @param redis.master.count Number of redis master replicas
-    count: 1
-
-    ## @param redis.master.persistence.enabled Enable persistence using Persistent Volume Claims
-    ## @param redis.master.persistence.size Pod pvc size
-    ## @param redis.master.persistence.storageClass Pod pvc storage class
-    ## @param redis.master.persistence.accessModes Pod pvc access modes
-    ## @param redis.master.persistence.annotations Pod pvc annotations
-    ## @param redis.master.persistence.existingClaim Pod pvc existing claim; necessary if using single_pvc
-    ## @param redis.master.persistence.subPath Subpath in PVC; necessary if using single_pvc (set it to `redis`)
-    persistence:
-      enabled: true
-      size: 8Gi
-      storageClass: ""
-      accessModes: [ReadWriteOnce]
-      existingClaim: ""
-      subPath: ""
-      annotations: {}
-
-  ## @param redis.replica.count Number of redis replicas (only if `redis.architecture=replication`)
-  ## Don't forget to configure replicas persistence if changing this value
-  replica:
-    count: 0
+    ## @param persistence.storageClass Storage class to use for persistent volume
+    storageClass: ""
+    ## @param persistence.accessMode Access mode for persistent volume
+    accessMode: ReadWriteOnce
+    ## @param persistence.size Size of persistent volume
+    size: 8Gi
+    ## @param persistence.mountPath Mount path for Redis data
+    mountPath: /data
+    ## @param persistence.annotations Annotations for persistent volume claims
+    annotations: {}
 
 ## @section Postfix parameters
 postfix:


### PR DESCRIPTION
Replacing bitnami redis with CloudPirates helm chart dependency. It has less features than the current bitnami chart, but has the advantage not to be made unavailable in august.