### PR TITLE
fix: pin tika image to 3.2.2.0-full

### DIFF
--- a/charts/mailu/README.md
+++ b/charts/mailu/README.md
@@ -968,7 +968,7 @@ Check that the deployed pods are all running.
 | `tika.logLevel`                              | Override default log level                                                                      | `""`            |
 | `tika.languages`                             | Array of languages to enable (sets the FULL_TEXT_SEARCH environment variable); "off" to disable | `["en"]`        |
 | `tika.image.repository`                      | Pod image repository                                                                            | `apache/tika`   |
-| `tika.image.tag`                             | Pod image tag                                                                                   | `latest-full`   |
+| `tika.image.tag`                             | Pod image tag                                                                                   | `3.2.2.0-full`  |
 | `tika.image.pullPolicy`                      | Pod image pull policy                                                                           | `IfNotPresent`  |
 | `tika.image.registry`                        | Pod image registry (specific for tika as it is not part of the mailu organization)              | `docker.io`     |
 | `tika.resources.limits`                      | The resources limits for the container                                                          | `{}`            |

--- a/charts/mailu/values.yaml
+++ b/charts/mailu/values.yaml
@@ -2896,7 +2896,7 @@ tika:
   ## @param tika.image.registry Pod image registry (specific for tika as it is not part of the mailu organization)
   image:
     repository: apache/tika
-    tag: latest-full
+    tag: 3.2.2.0-full
     pullPolicy: IfNotPresent
     registry: docker.io
 


### PR DESCRIPTION
This pull request updates the Apache Tika image version used by the Mailu Helm chart from a floating `latest-full` tag to the specific `3.2.2.0-full` tag. This change improves deployment stability by ensuring a consistent Tika version across environments.

Dependency version update:

* Updated the default Tika image tag in `charts/mailu/values.yaml` from `latest-full` to `3.2.2.0-full` to pin the deployed version.
* Updated the documentation in `charts/mailu/README.md` to reflect the new default Tika image tag.