### PR TITLE
fix: bump mailu version to 2024.06.43

### DIFF
--- a/charts/mailu/Chart.yaml
+++ b/charts/mailu/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2024.06.41
+appVersion: 2024.06.43
 version: 2.2.2
 name: mailu
 description: This chart installs the Mailu mail system on kubernetes


### PR DESCRIPTION
This pull request updates the `appVersion` in the `charts/mailu/Chart.yaml` file to reflect a newer version of the Mailu application. 

- Bumped the `appVersion` from `2024.06.41` to `2024.06.43` in `Chart.yaml` to track the latest Mailu release.