### PR TITLE
fix: common.ingress.supportsIngressClassname no longer exists

### DIFF
--- a/charts/mailu/ci/helm-lint-values.yaml
+++ b/charts/mailu/ci/helm-lint-values.yaml
@@ -113,10 +113,10 @@ rspamd:
   #   tag: master
   resources:
     requests:
-      memory: 100Mi
+      memory: 200Mi
       cpu: 100m
     limits:
-      memory: 200Mi
+      memory: 500Mi
       cpu: 1
 
 clamav:

--- a/charts/mailu/templates/front/ingress.yaml
+++ b/charts/mailu/templates/front/ingress.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
-  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:


### PR DESCRIPTION
The template was removed in bitnami.common. `ingressClassName` has been supported since k8s 1.18