### PR TITLE
fix: type of db ExtraEnvVars values

### DIFF
--- a/charts/mailu/templates/_database.tpl
+++ b/charts/mailu/templates/_database.tpl
@@ -125,12 +125,12 @@
 
 {{/* Return the database name for Roundcube */}}
 {{- define "mailu.database.roundcube.name" -}}
-{{- .Values.global.database.roundcube.database | quote }}
+{{- .Values.global.database.roundcube.database }}
 {{- end -}}
 
 {{/* Return the database username for Roundcube */}}
 {{- define "mailu.database.roundcube.username" -}}
-{{- .Values.global.database.roundcube.username | quote }}
+{{- .Values.global.database.roundcube.username }}
 {{- end -}}
 
 {{/* Return the database password for Roundcube */}}

--- a/charts/mailu/templates/envvars-configmap.yaml
+++ b/charts/mailu/templates/envvars-configmap.yaml
@@ -205,8 +205,8 @@ data:
 
 {{- if not (eq (include "mailu.database.type" .) "sqlite") }}
 {{- if .Values.webmail.enabled }}
-  ROUNDCUBE_DB_USER: {{ include "mailu.database.roundcube.username" . }}
-  ROUNDCUBE_DB_NAME: {{ include "mailu.database.roundcube.name" . }}
+  ROUNDCUBE_DB_USER: {{ include "mailu.database.roundcube.username" . | quote }}
+  ROUNDCUBE_DB_NAME: {{ include "mailu.database.roundcube.name" . | quote }}
   ROUNDCUBE_DB_HOST: {{ printf "%s:%s" (include "mailu.database.host" .) (include "mailu.database.port" .) | quote}}
 {{- end }}
 {{- end }}

--- a/charts/mailu/values.yaml
+++ b/charts/mailu/values.yaml
@@ -384,16 +384,16 @@ mariadb:
 
     ## @skip mariadb.primary.extraEnvVars
     ## Array with extra environment variables, used to create the initial Roundcube database; DO NOT EDIT; see `global.database` instead
-    extraEnvVars: |
+    extraEnvVars:
       - name: ROUNDCUBE_DB_PW
         valueFrom:
           secretKeyRef:
-            name: {{ include "mailu.database.roundcube.secretName" . }}
-            key: {{ include "mailu.database.roundcube.secretKey" . }}
+            name: '{{ include "mailu.database.roundcube.secretName" . }}'
+            key: '{{ include "mailu.database.roundcube.secretKey" . }}'
       - name: ROUNDCUBE_DB_NAME
-        value: {{ include "mailu.database.roundcube.name" . }}
+        value: '{{ include "mailu.database.roundcube.name" . }}'
       - name: ROUNDCUBE_DB_USER
-        value: {{ include "mailu.database.roundcube.username" . }}
+        value: '{{ include "mailu.database.roundcube.username" . }}'
 
   ## @skip mariadb.initdbScripts.create_roundcube_database.sh
   ## DO NOT EDIT Script to create the Roundcube database
@@ -479,16 +479,16 @@ postgresql:
   primary:
     ## @skip postgresql.primary.extraEnvVars
     ## Array with extra environment variables, used to create the initial Roundcube database; DO NOT EDIT; see `global.database` instead
-    extraEnvVars: |
+    extraEnvVars:
       - name: ROUNDCUBE_DB_PW
         valueFrom:
           secretKeyRef:
-            name: {{ include "mailu.database.roundcube.secretName" . }}
-            key: {{ include "mailu.database.roundcube.secretKey" . }}
+            name: '{{ include "mailu.database.roundcube.secretName" . }}'
+            key: '{{ include "mailu.database.roundcube.secretKey" . }}'
       - name: ROUNDCUBE_DB_NAME
-        value: {{ include "mailu.database.roundcube.name" . }}
+        value: '{{ include "mailu.database.roundcube.name" . }}'
       - name: ROUNDCUBE_DB_USER
-        value: {{ include "mailu.database.roundcube.username" . }}
+        value: '{{ include "mailu.database.roundcube.username" . }}'
 
     initdb:
       ## @skip postgresql.primary.initdb.scripts.create_roundcube_database.sh


### PR DESCRIPTION
fixes #463

# Context

MariaDB usage has been broken since Mailu Helm chart version [2.3.0](https://github.com/Mailu/helm-charts/releases/tag/mailu-2.3.0):
* PR #434 updated Bitnami's MariaDB chart dependency [from 12.2.* to 22.0.0](https://github.com/Mailu/helm-charts/pull/434/files#diff-9e8e21ca6e98690ad493e0741b9e43d13a88b957f0665f77c5b850cdb0383b33L40-R40).
* The JSON Schema of that more recent version of MariaDB chart [requires `*.extraEnvVars` helm values to be arrays, not strings](https://github.com/bitnami/charts/blob/mariadb/22.0.0/bitnami/mariadb/values.schema.json#L854-L859).

This PR fixes that issue by using the correct data type for these values in Mailu’s `values.yaml`.

Bitnami's helper function `common.tplvalues.render` that is [invoked](https://github.com/bitnami/charts/blob/mariadb/22.0.0/bitnami/mariadb/templates/primary/statefulset.yaml#L39) under the hood, [would have accepted both arrays and strings](https://github.com/bitnami/charts/blob/mariadb/22.0.0/bitnami/common/templates/_tplvalues.tpl#L14). However, due to the new restriction introduced in the MariaDB chart’s JSON schema, using an array is now mandatory.

# About PostgreSQL

For some reason, the type of `*.extraEnvVars` values is not defined in Bitnami's PostgresSQL chart [JSON Schema](https://github.com/bitnami/charts/blob/postgresql/16.7.27/bitnami/postgresql/values.schema.json). Therefore, Bitnami's PostgreSQL chart still accepts these values as either arrays or strings. That's why Mailu users that enabled PostgreSQL were not affected by this bug.

However it seems reasonable to keep the `extraEnvVars` values for both DBs in Mailu's chart consistent . That's why this PR also applies the same change to PostgreSQL-related values.

# Tests

This bug went unnoticed and affected multiple Mailu Helm chart releases because the GitHub Actions workflow in this repository [only test PostgreSQL](https://github.com/Mailu/helm-charts/blob/master/charts/mailu/ci/helm-lint-values.yaml#L22-L23), not MariaDB.