### PR TITLE
fix(github): BUG-issue-template values code block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ mailu:
   domain: "example.com"
   secretKey: "<redacted>"
   ...
+```
 
 **Additional information**
 Add any other context about the problem here, such as logs, error messages, or configurations.
-```


### PR DESCRIPTION
The code block for the `values.yaml` is currently ending after the next heading. Moving the line up to have proper formatting again