### PR TITLE
Revert "ci(github-release): update release python ( 3.13.7 ➔ 3.14.0 )"

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: "3.14"
+          python-version: "3.13"
           check-latest: true
 
       - name: Set up chart-testing

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
-          python-version: '3.14'
+          python-version: '3.13'
 
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@master


### PR DESCRIPTION
This reverts commit db2317053d3b3d14f1cb163f4bf67d8cab71348e.
It breaks the CI as 3.14 is not available for ubuntu 24.04