### PR TITLE
chore(renovate): require tests to pass for automerge

### DIFF
--- a/.renovate/autoMerge.json
+++ b/.renovate/autoMerge.json
@@ -18,7 +18,7 @@
                 "digest"
             ],
             "minimumReleaseAge": "1 minute",
-            "ignoreTests": true
+            "ignoreTests": false
         },
         {
             "description": "Auto-merge Mailu GitHub Releases",
@@ -34,7 +34,7 @@
             "matchPackageNames": [
                 "/Mailu/"
             ],
-            "ignoreTests": true
+            "ignoreTests": false
         }
     ]
 }


### PR DESCRIPTION
Prohibit renovate to push commits that break the CI