### PR TITLE
chore(deps): bump pre-commit repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
         exclude: >
@@ -11,11 +11,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23
+    rev: v0.1.30
     hooks:
       - id: helmlint
   - repo: https://github.com/bitnami/readme-generator-for-helm
-    rev: "2.6.1"
+    rev: "2.7.2"
     hooks:
       - id: helm-readme-generator
         # in order to run helm-readme-generator only once


### PR DESCRIPTION
This bumps the used pre-commit repos to their most recent versions which include bugfixes, removal of python3.8 

- pre-commit: Removal of python 3.8 support
- readme-generator: Dependency updates, bugfixes
- helmlint: Add support for terragrunt, tofu. Depencency updates.