### PR TITLE
fix: prevent overzealous whitespace removal

### DIFF
--- a/charts/mailu/templates/front/service-external.yaml
+++ b/charts/mailu/templates/front/service-external.yaml
@@ -21,7 +21,7 @@ spec:
     app.kubernetes.io/component: front
 {{- with .Values.front.externalService }}
   type: {{ .type | default "ClusterIP" }}
-  {{- if ne .type "ClusterIP" -}}
+  {{- if ne .type "ClusterIP" }}
   externalTrafficPolicy: {{ .externalTrafficPolicy | default "Local" }}
   {{- end }}
   {{- if .loadBalancerIP }}


### PR DESCRIPTION
Too much whitespace is removed here; if `.type` is `LoadBalancer` then `type` and `externalTrafficPolicy` end up on the same line producing invalid YAML. Removing the last dash means a newline will be inserted between the entries as expected.

Resolves #508