### PR TITLE
Add dnsPolicy and dnsConfig support to rspamd and webmail

### DIFF
--- a/charts/mailu/README.md
+++ b/charts/mailu/README.md
@@ -664,7 +664,7 @@ helm uninstall mailu --namespace=mailu-mailserver
 | `rspamd.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
 | `rspamd.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
 | `rspamd.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
-| `rspamd.dnsPolicy`                             | DNS Policy of the rspamd pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`) | `""`                |
+| `rspamd.dnsPolicy`                             | DNS Policy of the rspamd pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`)              |
 | `rspamd.dnsConfig`                             | DNS settings for the rspamd pod                                                       | `{}`                |
 | `rspamd.affinity`                              | Affinity for rspamd pod assignment                                                    | `{}`                |
 | `rspamd.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
@@ -799,7 +799,7 @@ helm uninstall mailu --namespace=mailu-mailserver
 | `webmail.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`                                                                            |
 | `webmail.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`                                                                           |
 | `webmail.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                                                                               |
-| `webmail.dnsPolicy`                             | DNS Policy of the webmail pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`) | `""`                                                                              |
+| `webmail.dnsPolicy`                             | DNS Policy of the webmail pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`)                                                                           |
 | `webmail.dnsConfig`                             | DNS settings for the webmail pod                                                      | `{}`                                                                              |
 | `webmail.affinity`                              | Affinity for webmail pod assignment                                                   | `{}`                                                                              |
 | `webmail.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                                                                              |

--- a/charts/mailu/README.md
+++ b/charts/mailu/README.md
@@ -664,6 +664,8 @@ helm uninstall mailu --namespace=mailu-mailserver
 | `rspamd.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`              |
 | `rspamd.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`             |
 | `rspamd.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                 |
+| `rspamd.dnsPolicy`                             | DNS Policy of the rspamd pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`) | `""`                |
+| `rspamd.dnsConfig`                             | DNS settings for the rspamd pod                                                       | `{}`                |
 | `rspamd.affinity`                              | Affinity for rspamd pod assignment                                                    | `{}`                |
 | `rspamd.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                |
 | `rspamd.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                 |
@@ -797,6 +799,8 @@ helm uninstall mailu --namespace=mailu-mailserver
 | `webmail.containerSecurityContext.runAsUser`    | Set containers' Security Context runAsUser                                            | `1001`                                                                            |
 | `webmail.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                         | `false`                                                                           |
 | `webmail.terminationGracePeriodSeconds`         | In seconds, time given to the pod to terminate gracefully                             | `2`                                                                               |
+| `webmail.dnsPolicy`                             | DNS Policy of the webmail pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`) | `""`                                                                              |
+| `webmail.dnsConfig`                             | DNS settings for the webmail pod                                                      | `{}`                                                                              |
 | `webmail.affinity`                              | Affinity for webmail pod assignment                                                   | `{}`                                                                              |
 | `webmail.tolerations`                           | Tolerations for pod assignment                                                        | `[]`                                                                              |
 | `webmail.revisionHistoryLimit`                  | Configure the revisionHistoryLimit of the deployment                                  | `3`                                                                               |

--- a/charts/mailu/templates/rspamd/deployment.yaml
+++ b/charts/mailu/templates/rspamd/deployment.yaml
@@ -58,6 +58,12 @@ spec:
       {{- if .Values.rspamd.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.rspamd.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if .Values.rspamd.dnsPolicy }}
+      dnsPolicy: {{ .Values.rspamd.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.rspamd.dnsConfig }}
+      dnsConfig: {{- include "mailu.tplvalues.render" (dict "value" .Values.rspamd.dnsConfig "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.rspamd.initContainers }}
       initContainers: {{- include "mailu.tplvalues.render" (dict "value" .Values.rspamd.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/mailu/templates/webmail/deployment.yaml
+++ b/charts/mailu/templates/webmail/deployment.yaml
@@ -58,6 +58,12 @@ spec:
       {{- if .Values.webmail.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.webmail.terminationGracePeriodSeconds }}
       {{- end }}
+      {{- if .Values.webmail.dnsPolicy }}
+      dnsPolicy: {{ .Values.webmail.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.webmail.dnsConfig }}
+      dnsConfig: {{- include "mailu.tplvalues.render" (dict "value" .Values.webmail.dnsConfig "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.webmail.initContainers }}
       initContainers: {{- include "mailu.tplvalues.render" (dict "value" .Values.webmail.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/charts/mailu/values.yaml
+++ b/charts/mailu/values.yaml
@@ -1920,6 +1920,14 @@ rspamd:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
 
+  ## @param rspamd.dnsPolicy DNS Policy of the rspamd pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`)
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: ""
+
+  ## @param rspamd.dnsConfig DNS settings for the rspamd pod
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
+
   ## @param rspamd.affinity Affinity for rspamd pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
@@ -2400,6 +2408,14 @@ webmail:
   ## @param webmail.terminationGracePeriodSeconds In seconds, time given to the pod to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   terminationGracePeriodSeconds: 2
+
+  ## @param webmail.dnsPolicy DNS Policy of the webmail pod (`Default`, `ClusterFirst`, `ClusterFirstWithHostNet` and `None`)
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  dnsPolicy: ""
+
+  ## @param webmail.dnsConfig DNS settings for the webmail pod
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
 
   ## @param webmail.affinity Affinity for webmail pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
Similar to what is already done for the admin pod, this PR adds the ability to configure dnsPolicy and dnsConfig for the rspamd and webmail components. This allows users to customize DNS settings for these specific pods, which is useful for environments requiring custom DNS servers, search domains, or options (e.g., tuning ndots).

Example of configuration I needed to get this working on my cluster:

```
rspamd:
  dnsPolicy: "ClusterFirst"
  dnsConfig:
    options:
      - name: ndots
        value: "1"
      - name: single-request-reopen
 ```