### PR TITLE
fix: fallback to standard mail ports when no exposure method configured

### DIFF
--- a/charts/mailu/templates/_services.tpl
+++ b/charts/mailu/templates/_services.tpl
@@ -208,6 +208,11 @@ Service fqdn (within cluster) can be retrieved with `mailu.SERVICE.serviceFqdn`
     {{- end -}}
 {{- end -}}
 
+{{- /* Fallback to standard mail ports when using external ingress */ -}}
+{{- if not $enabledPorts -}}
+    {{- $enabledPorts = list "25" "465" "587" "143" "993" -}}
+{{- end -}}
+
 {{- $enabledPortsString := join "," $enabledPorts -}}
 {{- printf "%s" $enabledPortsString -}}
 {{- end -}}


### PR DESCRIPTION
## Summary

When using an external ingress controller (e.g., Traefik with TCP routing), all built-in exposure methods are disabled (`ingress.enabled`, `front.hostPort.enabled`, `front.externalService.enabled` all set to `false`).

This results in an empty `PORTS` environment variable in the `mailu-envvars` ConfigMap, which can cause issues in the admin UI (see Mailu/Mailu#3944).

This PR adds a fallback to standard mail ports (`25,465,587,143,993`) when no ports are detected through the existing logic.

## Changes

- Added fallback in `mailu.enabledPorts` helper when no exposure method is configured

## Testing

```bash
helm template mailu charts/mailu \
  --set ingress.enabled=false \
  --set front.hostPort.enabled=false \
  --set front.externalService.enabled=false \
  | grep -A1 "PORTS:"
```

**Before:** `PORTS: ""`
**After:** `PORTS: "25,465,587,143,993"`

Fixes #548