### PR TITLE
fix(dovecot): correct existingClaim reference in pvc template

### DIFF
--- a/charts/mailu/Chart.yaml
+++ b/charts/mailu/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 # renovate: datasource=github-releases depName=Mailu/mailu
 appVersion: 2024.06.49
-version: 2.6.3
+version: 2.6.4
 name: mailu
 description: This chart installs the Mailu mail system on Kubernetes
 home: https://mailu.io

--- a/charts/mailu/templates/dovecot/pvc.yaml
+++ b/charts/mailu/templates/dovecot/pvc.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if .Values.dovecot.enabled }}
-{{- if and (not .Values.persistence.single_pvc) (not .Values.postfix.persistence.existingClaim)}}
+{{- if and (not .Values.persistence.single_pvc) (not .Values.dovecot.persistence.existingClaim)}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Hello!

I noticed the Dovecot PVC template was checking for Postfix's existingClaim instead of its own, so existingClaim did not work.

