### PR TITLE
fix(ingress): terminate HTTP TLS at external ingress.

### DIFF
--- a/charts/mailu/templates/_helpers.tpl
+++ b/charts/mailu/templates/_helpers.tpl
@@ -68,16 +68,18 @@ Get MailU domain name or throw an error if not set
 {{- end -}}
 {{- end -}}
 
-{{/* Get the MailU TLS Flavor */}}
+{{/* Get the Mailu TLS Flavor */}}
 {{- define "mailu.tlsFlavor" -}}
 {{- if .Values.ingress.tlsFlavorOverride -}}
-{{- .Values.ingress.tlsFlavorOverride -}}
+  {{- .Values.ingress.tlsFlavorOverride -}}
+{{- else if .Values.ingress.tls -}}
+  {{- if .Values.ingress.enabled -}}
+    {{- print "mail" -}}
+  {{- else -}}
+    {{- print "cert" -}}
+  {{- end -}}
 {{- else -}}
-    {{- if .Values.ingress.tls -}}
-        {{- print "cert" -}}
-    {{- else -}}
-        {{- print "notls" -}}
-    {{- end -}}
+  {{- print "notls" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/mailu/templates/front/ingress.yaml
+++ b/charts/mailu/templates/front/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     {{- include "mailu.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     {{- if .Values.ingress.annotations }}
     {{- include "mailu.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
     {{- end }}
@@ -32,7 +31,7 @@ spec:
           {{- end }}
           - path: {{ $.Values.ingress.path }}
             pathType: {{ $.Values.ingress.pathType }}
-            backend: {{- include "mailu.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "https" "context" $)  | nindent 14 }}
+            backend: {{- include "mailu.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name | quote }}
@@ -40,7 +39,7 @@ spec:
         paths:
           - path: {{ default "/" .path }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            backend: {{- include "mailu.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "https" "context" $) | nindent 14 }}
+            backend: {{- include "mailu.ingress.backend" (dict "serviceName" (include "mailu.front.serviceName" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
     {{- include "mailu.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}


### PR DESCRIPTION
There are too many specifics that change the existing working ingress behavior. 
This is an attempt to integrate ingress to an existing nginx/traefik router configuration.

When ingress.enabled=true, the Kubernetes Ingress is responsible for HTTP(S) TLS termination.

- Route the Ingress backend to mailu-front:http instead of https.
- Do not add the nginx HTTPS backend annotation. It was unconditional and is not required.
- Automatically use TLS_FLAVOR=mail when ingress TLS is enabled so SMTP/IMAP TLS continues to use the certificate without causing HTTP redirect loops.
| `ingress.enabled` | `ingress.tls` | Automatic `TLS_FLAVOR` | HTTP backend         |
| ----------------- | ------------- | ---------------------- | -------------------- |
| true              | true          | `mail`                 | `http:80`            |
| true              | false         | `notls`                | `http:80`            |
| false             | true          | `cert`                 | internal Mailu HTTPS |
| false             | false         | `notls`                | internal Mailu HTTP  |

- Preserve tlsFlavorOverride for custom configurations.

Fixes #541.